### PR TITLE
[fix/product] 상품 카드 할인가 계산 로직 수정

### DIFF
--- a/src/components/common/ProductCard.tsx
+++ b/src/components/common/ProductCard.tsx
@@ -13,7 +13,10 @@ const ProductCard = ({ product }: ProductCardProps) => {
   const { id, productName, img1, brand, price, sale, liked } = product;
 
   const formattedPrice = new Intl.NumberFormat("ko-KR").format(price);
-  const formattedSale = new Intl.NumberFormat("ko-KR").format(sale);
+  
+  // sale이 할인율(%)인 경우 실제 할인가 계산
+  const discountedPrice = sale > 0 ? Math.round(price * (1 - sale / 100)) : price;
+  const formattedDiscountedPrice = new Intl.NumberFormat("ko-KR").format(discountedPrice);
 
   const { isWished, toggleWishlist } = useWishlist(liked, id);
   const { tryOnProduct } = useAvatarTryon();
@@ -91,9 +94,11 @@ const ProductCard = ({ product }: ProductCardProps) => {
           <div className="h-[40px]">
             {sale > 0 ? (
               <div>
+                {/* 할인가 */}
                 <div className="text-base font-bold text-red-500">
-                  {formattedSale}원
+                  {formattedDiscountedPrice}원
                 </div>
+                {/* 정가 */}
                 <div className="text-sm text-gray-400 line-through">
                   {formattedPrice}원
                 </div>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

>  #26

---

## 📝 작업 내용

> db의 sale 필드를 할인율(%)로 해석하여 실제 할인가를 계산해주었습니다.
> 할인 상품은 할인가는 빨간색으로 정가는 취소선으로 표시해주었습니다.
> 일반 상품은 정가만 표시되도록 하였고,
> 메인/ 카테고리 페이지에서 상세 페이지와 동일한 할인 표시를 구현되게 수정하였습니다.


---

### 📷 스크린샷 (선택)

<img width="859" alt="image" src="https://github.com/user-attachments/assets/c61ed15e-5abf-4b6a-8d71-bebb0c5eb5d6" />

<img width="1358" alt="image" src="https://github.com/user-attachments/assets/d08b3b9a-5072-4693-9346-060bba19c486" />

