### PR TITLE
fix: zustand store persist 일괄 적용

### DIFF
--- a/src/stores/google-token-store.ts
+++ b/src/stores/google-token-store.ts
@@ -1,5 +1,6 @@
 // Oauth google 인증 절차의 id token 저장소
 import { createStore } from "zustand/vanilla";
+import { persist } from "zustand/middleware";
 
 export type IdTokenState = {
   idToken: string;
@@ -18,10 +19,17 @@ export const defaultInitState: IdTokenState = {
 export const createIdTokenStore = (
   initState: IdTokenState = defaultInitState
 ) => {
-  return createStore<IdTokenStore>()((set) => ({
-    ...initState,
-    setIdToken: (idToken: string) => set(() => ({ idToken })),
-  }));
+  return createStore<IdTokenStore>()(
+    persist(
+      (set) => ({
+        ...initState,
+        setIdToken: (idToken: string) => set(() => ({ idToken })),
+      }),
+      {
+        name: "google-token-storage",
+      }
+    )
+  );
 };
 
 export const idTokenStore = createIdTokenStore();


### PR DESCRIPTION
배포서버에서 google token 누락되는 현상이 발생하여, 이를 개선하고자 zustand 전역 상태관리 방법을 변경하였습니다. localstorage에 저장되는 persist를 적용하였습니다.