### PR TITLE
[feat] 좌측 착장 아바타 홈페이지 렌더링 수정 & 입은 상품 렌더링

### DIFF
--- a/src/app/(home)/_components/HomeClient.tsx
+++ b/src/app/(home)/_components/HomeClient.tsx
@@ -5,6 +5,7 @@ import MainProductList from "@/app/(home)/_components/MainProductList";
 import CategoryProductList from "@/app/(home)/_components/CategoryProductList";
 import AvatarLayout from "@/components/layout/AvatarProducts";
 import { getAccessToken } from "@/utils/auth";
+import AvatarWearInfo from "@/components/common/AvatarWearInfo";
 
 type HomeClientProps = {
   initialData: MainProductResponse;
@@ -15,13 +16,17 @@ const HomeClient = ({ initialData }: HomeClientProps) => {
   const token = getAccessToken();
   const isLoggedIn = !!token;
 
-  // 기본 아바타 슬롯 (avatarInfo 없이)
+  // 기본 아바타 슬롯 (비로그인 사용자용)
   const defaultAvatarSlot = (
-    <div className="w-full min-h-[30vh] p-4 bg-gray-50 rounded-xl shadow-sm flex flex-col items-center justify-center">
+    <div className="w-full h-screen p-4 bg-gray-50 rounded-xl shadow-sm flex flex-col items-center justify-center">
       <div className="text-6xl mb-4">👤</div>
-      <p className="text-gray-600 text-center mb-2">나만의 아바타로 옷을 입어보세요!</p>
+      <p className="text-gray-600 text-center mb-2">
+        나만의 아바타로 옷을 입어보세요!
+      </p>
       <p className="text-gray-500 text-sm text-center">
-        {isLoggedIn ? "아바타 정보를 불러오는 중..." : "로그인하면 개인화된 아바타를 사용할 수 있습니다."}
+        {isLoggedIn
+          ? "아바타 정보를 불러오는 중..."
+          : "로그인하면 개인화된 아바타를 사용할 수 있습니다."}
       </p>
     </div>
   );
@@ -29,13 +34,13 @@ const HomeClient = ({ initialData }: HomeClientProps) => {
   // 로그인된 사용자와 비로그인 사용자 구분 처리
   if (isLoggedIn && initialData.recommended && initialData.ranked) {
     // 로그인된 사용자 - 기존 추천/인기 상품 방식
-    console.log('로그인된 사용자 - 추천/인기 상품 표시');
+    console.log("로그인된 사용자 - 추천/인기 상품 표시");
     const recommended = initialData.recommended;
     const ranked = initialData.ranked;
 
     return (
       <AvatarLayout
-        avatarSlot={defaultAvatarSlot}
+        avatarSlot={<AvatarWearInfo />}
         productSlot={
           <MainProductList recommended={recommended} ranked={ranked} />
         }
@@ -43,15 +48,13 @@ const HomeClient = ({ initialData }: HomeClientProps) => {
     );
   } else if (initialData.categories) {
     // 비로그인 사용자 - 카테고리별 표시
-    console.log('비로그인 사용자 - 카테고리별 상품 표시');
+    console.log("비로그인 사용자 - 카테고리별 상품 표시");
     const categories = initialData.categories;
 
     return (
       <AvatarLayout
         avatarSlot={defaultAvatarSlot}
-        productSlot={
-          <CategoryProductList categories={categories} />
-        }
+        productSlot={<CategoryProductList categories={categories} />}
       />
     );
   } else {
@@ -60,8 +63,8 @@ const HomeClient = ({ initialData }: HomeClientProps) => {
       <div className="flex items-center justify-center min-h-screen">
         <div className="text-center">
           <p className="text-gray-600 mb-4">상품 정보를 불러올 수 없습니다.</p>
-          <button 
-            onClick={() => window.location.reload()} 
+          <button
+            onClick={() => window.location.reload()}
             className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
           >
             다시 시도


### PR DESCRIPTION
- 홈페이지의 좌측 착장 아바타가 다른 페이지와 동일하게 렌더링 되도록 수정했습니다.
- 입은 상품이 뜨지 않는 에러를 수정하였습니다.
  (Application error: a client-side exception has occurred while loading tio-style.com (see the browser console for more information)
<img width="1440" alt="스크린샷 2025-07-08 오후 4 00 23" src="https://github.com/user-attachments/assets/71f22b81-6ed0-4a65-96a9-b6761968500b" />
