### PR TITLE
[fix/tryon] try on 전역 상태 타입을 response DTO에 맞춰 수정

### DIFF
--- a/src/api/avatar.ts
+++ b/src/api/avatar.ts
@@ -1,6 +1,5 @@
 import { AvatarRequest, AvatarResponse } from "@/types/avatar";
 import { axiosWithAuth } from "@/api";
-import type { AvatarProductInfo } from "@/types/avatar";
 
 export const createAvatar = async (
   data: AvatarRequest
@@ -9,7 +8,7 @@ export const createAvatar = async (
   return response.data;
 };
 
-export const fetchLatestAvatarInfo = async (): Promise<AvatarProductInfo> => {
+export const fetchLatestAvatarInfo = async (): Promise<AvatarResponse> => {
   const response = await axiosWithAuth().get("/api/avatars/latest-info");
   return response.data;
 };

--- a/src/app/(home)/_components/CategoryProductList.tsx
+++ b/src/app/(home)/_components/CategoryProductList.tsx
@@ -10,10 +10,10 @@ type CategoryProductListProps = {
 };
 
 const CategoryProductList = ({ categories }: CategoryProductListProps) => {
-  console.log('카테고리별 상품 표시:', categories.length, '개 카테고리');
+  console.log("카테고리별 상품 표시:", categories.length, "개 카테고리");
 
   return (
-    <div className="space-y-12">
+    <div className="space-y-12 py-8 px-4">
       {categories.map((category) => (
         <section key={category.categoryId}>
           <h3 className="text-xl font-semibold mb-4 text-black">

--- a/src/app/(home)/_components/HomeClient.tsx
+++ b/src/app/(home)/_components/HomeClient.tsx
@@ -6,6 +6,7 @@ import CategoryProductList from "@/app/(home)/_components/CategoryProductList";
 import AvatarLayout from "@/components/layout/AvatarProducts";
 import { getAccessToken } from "@/utils/auth";
 import AvatarWearInfo from "@/components/common/AvatarWearInfo";
+import DefaultAvatarSlot from "@/components/common/DefaultAvatarSlot";
 
 type HomeClientProps = {
   initialData: MainProductResponse;
@@ -15,21 +16,6 @@ const HomeClient = ({ initialData }: HomeClientProps) => {
   // 로그인 상태 확인
   const token = getAccessToken();
   const isLoggedIn = !!token;
-
-  // 기본 아바타 슬롯 (비로그인 사용자용)
-  const defaultAvatarSlot = (
-    <div className="w-full h-screen p-4 bg-gray-50 rounded-xl shadow-sm flex flex-col items-center justify-center">
-      <div className="text-6xl mb-4">👤</div>
-      <p className="text-gray-600 text-center mb-2">
-        나만의 아바타로 옷을 입어보세요!
-      </p>
-      <p className="text-gray-500 text-sm text-center">
-        {isLoggedIn
-          ? "아바타 정보를 불러오는 중..."
-          : "로그인하면 개인화된 아바타를 사용할 수 있습니다."}
-      </p>
-    </div>
-  );
 
   // 로그인된 사용자와 비로그인 사용자 구분 처리
   if (isLoggedIn && initialData.recommended && initialData.ranked) {
@@ -53,7 +39,7 @@ const HomeClient = ({ initialData }: HomeClientProps) => {
 
     return (
       <AvatarLayout
-        avatarSlot={defaultAvatarSlot}
+        avatarSlot={<DefaultAvatarSlot />}
         productSlot={<CategoryProductList categories={categories} />}
       />
     );

--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -16,28 +16,28 @@ export default function Home() {
     const loadData = async () => {
       try {
         setLoading(true);
-        
+
         // 로그인 상태 확인 (인증 유틸 함수 사용)
         const token = getAccessToken();
-        
-        console.log('토큰 상태:', token ? '있음' : '없음');
-        
+
+        console.log("토큰 상태:", token ? "있음" : "없음");
+
         if (token) {
-          console.log('🔐 로그인된 사용자 - 개인화된 데이터 로드');
+          console.log("🔐 로그인된 사용자 - 개인화된 데이터 로드");
           try {
             const result = await fetchMainProducts();
-            console.log('✅ 로그인용 API 성공:', result);
-            console.log('recommended 개수:', result.recommended?.length || 0);
-            console.log('ranked 개수:', result.ranked?.length || 0);
+            console.log("✅ 로그인용 API 성공:", result);
+            console.log("recommended 개수:", result.recommended?.length || 0);
+            console.log("ranked 개수:", result.ranked?.length || 0);
             setData(result);
           } catch (authError) {
-            console.error('❌ 개인화된 데이터 로드 실패:', authError);
-            console.log('비로그인 데이터로 대체');
+            console.error("❌ 개인화된 데이터 로드 실패:", authError);
+            console.log("비로그인 데이터로 대체");
             const result = await fetchMainProductsForGuest();
             setData(result);
           }
         } else {
-          console.log('👤 비로그인 사용자 - 카테고리별 인기 상품 로드');
+          console.log("👤 비로그인 사용자 - 카테고리별 인기 상품 로드");
           const result = await fetchMainProductsForGuest();
           setData(result);
         }
@@ -45,7 +45,7 @@ export default function Home() {
         console.error("메인 상품 데이터를 불러오는 데 실패했습니다", error);
         setError("상품 정보를 불러올 수 없습니다.");
         // 에러 발생 시 Mock 데이터 사용
-        console.log('❌ 에러 발생 - Mock 데이터 사용');
+        console.log("❌ 에러 발생 - Mock 데이터 사용");
         setData(mainProductsDummy);
       } finally {
         setLoading(false);
@@ -57,7 +57,7 @@ export default function Home() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center min-h-screen">
+      <div className="flex items-center justify-center min-h-screen w-screen">
         <div className="text-center">
           <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto mb-4"></div>
           <p className="text-gray-600">상품 정보를 불러오는 중...</p>
@@ -68,11 +68,11 @@ export default function Home() {
 
   if (error && !data) {
     return (
-      <div className="flex items-center justify-center min-h-screen">
+      <div className="flex items-center justify-center min-h-screen w-screen">
         <div className="text-center">
           <p className="text-red-600 mb-4">{error}</p>
-          <button 
-            onClick={() => window.location.reload()} 
+          <button
+            onClick={() => window.location.reload()}
             className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
           >
             다시 시도

--- a/src/app/category/[id]/_components/CategoryAvatarClient.tsx
+++ b/src/app/category/[id]/_components/CategoryAvatarClient.tsx
@@ -7,20 +7,17 @@ import { useAvatarStore } from "@/stores/avatar-store";
 import { getAccessToken } from "@/utils/auth";
 import { fetchLatestAvatarInfo } from "@/api/avatar";
 import AvatarWearInfo from "@/components/common/AvatarWearInfo";
+import DefaultAvatarSlot from "@/components/common/DefaultAvatarSlot";
 
 const CategoryAvatarClient = () => {
   const setAvatarImg = useAvatarStore((state) => state.setAvatarImg);
 
+  const token = getAccessToken();
+  const isLoggedIn = !!token;
+
   useEffect(() => {
     const loadAvatarInfo = async () => {
       try {
-        const token = getAccessToken();
-        if (!token) {
-          // 로그인하지 않은 경우 기본 아바타 이미지 설정
-          setAvatarImg("/images/default-avatar.png");
-          return;
-        }
-
         const data = await fetchLatestAvatarInfo();
         setAvatarImg(data.avatarImg); // 전역 상태 업데이트
       } catch (error) {
@@ -33,8 +30,11 @@ const CategoryAvatarClient = () => {
     loadAvatarInfo();
   }, [setAvatarImg]);
 
-  // AvatarWearInfo 컴포넌트는 내부적으로 avatar store를 사용하므로 props 없이 사용
-  return <AvatarWearInfo />;
+  if (isLoggedIn) {
+    return <AvatarWearInfo />;
+  } else {
+    return <DefaultAvatarSlot />;
+  }
 };
 
 export default CategoryAvatarClient;

--- a/src/app/detail/[id]/_components/DetailMainImg.tsx
+++ b/src/app/detail/[id]/_components/DetailMainImg.tsx
@@ -8,6 +8,7 @@ import "swiper/css/navigation";
 import { Navigation } from "swiper/modules";
 import { useState } from "react";
 import AvatarModal from "@/components/ui/AvatarModal";
+import { getAccessToken } from "@/utils/auth";
 
 type DetailMainImgProps = {
   images: string[];
@@ -15,6 +16,17 @@ type DetailMainImgProps = {
 
 const DetailMainImg = ({ images }: DetailMainImgProps) => {
   const [tryon, setTryon] = useState(false);
+
+  const token = getAccessToken();
+  const isLoggedIn = !!token;
+
+  const handleModalOpen = () => {
+    if (isLoggedIn) {
+      setTryon(true);
+    } else {
+      alert("로그인이 필요한 기능입니다.");
+    }
+  };
 
   const handleModalClose = () => {
     setTryon(false);
@@ -38,7 +50,7 @@ const DetailMainImg = ({ images }: DetailMainImgProps) => {
               width={50}
               height={50}
               alt="입어보기"
-              onClick={() => setTryon(true)}
+              onClick={handleModalOpen}
             />
           </div>
 

--- a/src/components/common/AvatarWearInfo.tsx
+++ b/src/components/common/AvatarWearInfo.tsx
@@ -4,10 +4,9 @@ import React, { useState } from "react";
 import Image from "next/image";
 import { useAvatarStore } from "@/stores/avatar-store";
 import { saveClosetAvatar } from "@/api/closet";
-import { ClosetAvatarResponse } from "@/types/closet";
 
 const AvatarWearInfo = () => {
-  const avatarImg = useAvatarStore((state) => state.avatarImg);
+  const avatarInfo = useAvatarStore((state) => state.avatarInfo);
   const selectedProductIds = useAvatarStore(
     (state) => state.selectedProductIds
   );
@@ -15,9 +14,9 @@ const AvatarWearInfo = () => {
   const [isClosetLoading, setIsClosetLoading] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
 
-  const [avatar, setAvatar] = useState<ClosetAvatarResponse | null>(null);
-
   const handleAddToCloset = async () => {
+    console.log("전역 관리 중인 선택된 상품 id: ", selectedProductIds);
+
     try {
       setIsClosetLoading(true);
       setMessage(null);
@@ -37,7 +36,6 @@ const AvatarWearInfo = () => {
       });
 
       console.log("Closet save response:", response);
-      setAvatar(response);
       setMessage("옷장에 성공적으로 추가되었습니다!");
 
       // 3초 후 메시지 제거
@@ -74,7 +72,7 @@ const AvatarWearInfo = () => {
         className={`absolute top-4 right-4 z-10 px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
           isClosetLoading || isAvatarLoading
             ? "bg-gray-300 text-gray-500 cursor-not-allowed"
-            : "bg-blue-500 text-white hover:bg-blue-600"
+            : "bg-black text-white hover:bg-neutral-600"
         }`}
         aria-label="옷장에 추가"
       >
@@ -104,10 +102,10 @@ const AvatarWearInfo = () => {
 
       {/* 아바타 이미지 */}
       <div className="w-full flex justify-center mb-6 relative">
-        {avatarImg ? (
+        {avatarInfo.avatarImgUrl ? (
           <div className="relative">
             <Image
-              src={avatarImg}
+              src={avatarInfo.avatarImgUrl}
               alt="착장한 아바타"
               width={180}
               height={180}
@@ -137,15 +135,13 @@ const AvatarWearInfo = () => {
 
       {/* 착장 상품 리스트 */}
       <div>
-        {avatar && Object.keys(avatar.itemsByCategory).length > 0 ? (
+        {avatarInfo && avatarInfo.products.length > 0 ? (
           <ul className="list-disc list-inside text-sm text-gray-700 space-y-1">
-            {Object.entries(avatar.itemsByCategory).map(
-              ([categoryName, product]) => (
-                <li key={product.productId}>
-                  {categoryName} / {product.productName} ({product.brand})
-                </li>
-              )
-            )}
+            {avatarInfo.products.map((product, idx) => (
+              <li key={idx}>
+                {product.categoryName} / {product.productName}
+              </li>
+            ))}
           </ul>
         ) : (
           <p className="text-sm text-gray-500">

--- a/src/components/common/DefaultAvatarSlot.tsx
+++ b/src/components/common/DefaultAvatarSlot.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+
+// 기본 아바타 슬롯 (비로그인 사용자용)
+const DefaultAvatarSlot = () => {
+  return (
+    <div className="w-full h-[85vh] p-4 bg-gray-50 rounded-xl shadow-sm flex flex-col items-center justify-center gap-3">
+      <div className="text-6xl mb-4">👤</div>
+      <p className="text-gray-600 text-center mb-4">
+        나만의 아바타로 <br />
+        옷을 입어보세요!
+      </p>
+      <p className="text-gray-500 text-sm text-center">
+        로그인하면 나의 아바타를 등록할 수 있습니다.
+      </p>
+    </div>
+  );
+};
+
+export default DefaultAvatarSlot;

--- a/src/components/common/ProductCard.tsx
+++ b/src/components/common/ProductCard.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { ProductResponse } from "@/types/product";
 import { useWishlist } from "@/hooks/useWishlist";
 import { useAvatarTryon } from "@/hooks/useAvatarTryon";
+import { getAccessToken } from "@/utils/auth";
 
 type ProductCardProps = {
   product: ProductResponse;
@@ -11,18 +12,21 @@ type ProductCardProps = {
 
 const ProductCard = ({ product }: ProductCardProps) => {
   const { id, productName, img1, brand, price, sale, liked } = product;
-  
+
   // API 응답에서 다른 필드명으로 올 수 있는 값들 처리
   const imageUrl = (product as any).imageUrl || img1;
   const actualProductName = (product as any).name || productName; // API에서 name으로 옴
   const actualSale = sale || 0; // API에서 sale이 없으면 0 (할인 없음)
   const actualLiked = liked || false; // API에서 liked가 없으면 false
-  
+
   // alt 텍스트를 안전하게 생성
   const altText = (() => {
-    const safeBrand = brand && brand.trim() !== '' ? brand.trim() : '';
-    const safeName = actualProductName && actualProductName.trim() !== '' ? actualProductName.trim() : '';
-    
+    const safeBrand = brand && brand.trim() !== "" ? brand.trim() : "";
+    const safeName =
+      actualProductName && actualProductName.trim() !== ""
+        ? actualProductName.trim()
+        : "";
+
     if (safeBrand && safeName) {
       return `${safeBrand} ${safeName}`;
     } else if (safeName) {
@@ -30,15 +34,18 @@ const ProductCard = ({ product }: ProductCardProps) => {
     } else if (safeBrand) {
       return `${safeBrand} 상품`;
     } else {
-      return '상품 이미지';
+      return "상품 이미지";
     }
   })();
 
   const formattedPrice = new Intl.NumberFormat("ko-KR").format(price);
-  
+
   // sale이 할인율(%)인 경우 실제 할인가 계산
-  const discountedPrice = actualSale > 0 ? Math.round(price * (1 - actualSale / 100)) : price;
-  const formattedDiscountedPrice = new Intl.NumberFormat("ko-KR").format(discountedPrice);
+  const discountedPrice =
+    actualSale > 0 ? Math.round(price * (1 - actualSale / 100)) : price;
+  const formattedDiscountedPrice = new Intl.NumberFormat("ko-KR").format(
+    discountedPrice
+  );
 
   const { isWished, toggleWishlist } = useWishlist(liked, id);
   const { tryOnProduct } = useAvatarTryon();
@@ -46,6 +53,13 @@ const ProductCard = ({ product }: ProductCardProps) => {
   const handleAvatarClick = async (e: React.MouseEvent) => {
     e.preventDefault(); // Link 클릭 방지
     e.stopPropagation(); // 이벤트 버블링 방지
+
+    // 로그인 확인
+    const token = getAccessToken();
+    if (!token) {
+      alert("로그인이 필요한 기능입니다.");
+      return;
+    }
 
     try {
       await tryOnProduct(id);
@@ -63,14 +77,18 @@ const ProductCard = ({ product }: ProductCardProps) => {
       <div className="w-full h-[240px] bg-gray-100 relative">
         <Link href={`/detail/${id}`}>
           <Image
-            src={imageUrl && imageUrl.trim() !== '' ? imageUrl : '/images/no-image.svg'}
+            src={
+              imageUrl && imageUrl.trim() !== ""
+                ? imageUrl
+                : "/images/no-image.svg"
+            }
             alt={altText}
             fill
             className="object-contain p-2"
             onError={(e) => {
               // 이미지 로드 실패 시 기본 이미지로 대체
               const target = e.target as HTMLImageElement;
-              target.src = '/images/no-image.svg';
+              target.src = "/images/no-image.svg";
             }}
           />
         </Link>
@@ -111,10 +129,12 @@ const ProductCard = ({ product }: ProductCardProps) => {
       <Link href={`/detail/${id}`}>
         <div className="p-4">
           <div className="text-sm font-semibold text-gray-900 mb-1">
-            {brand && brand.trim() !== '' ? brand : '브랜드명 없음'}
+            {brand && brand.trim() !== "" ? brand : "브랜드명 없음"}
           </div>
           <div className="text-base font-bold text-black truncate mb-2">
-            {actualProductName && actualProductName.trim() !== '' ? actualProductName : '상품명 없음'}
+            {actualProductName && actualProductName.trim() !== ""
+              ? actualProductName
+              : "상품명 없음"}
           </div>
 
           {/* 가격 정보 */}

--- a/src/components/ui/AvatarModal.tsx
+++ b/src/components/ui/AvatarModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { createAvatar } from "@/api/avatar";
+import { useAvatarStore } from "@/stores/avatar-store";
 import { AvatarResponse } from "@/types/avatar";
 import Image from "next/image";
 import { useParams } from "next/navigation";
@@ -15,18 +16,21 @@ const AvatarModal = ({ onClose }: AvatarModalProps) => {
   const id = Number(params?.id);
 
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(false);
   const [avatar, setAvatar] = useState<AvatarResponse>({
     avatarId: id,
-    avatarImgUrl: "/images/dummy/ex10.png",
+    avatarImgUrl: "",
     products: [],
   });
 
   const makeAvatar = async () => {
     try {
+      setLoading(true);
       const response = await createAvatar({ productId: id });
       setAvatar(response);
     } catch (error) {
       console.error("아바타 생성 실패", error);
+      setError(true);
     } finally {
       setLoading(false);
     }
@@ -39,12 +43,35 @@ const AvatarModal = ({ onClose }: AvatarModalProps) => {
   return (
     <div className="fixed top-0 left-0 w-full h-full flex justify-center items-center bg-[rgba(0,0,0,0.25)] z-40">
       <div className="relative w-[40rem] h-[80vh] bg-[rgba(233,233,233,0.95)] rounded-lg shadow-lg p-6 flex flex-col items-center justify-center">
-        {loading ? (
+        {/* 닫기 버튼 */}
+        <div className="absolute top-6 right-8 cursor-pointer">
+          <Image
+            src="/images/common/close_icon.svg"
+            width={15}
+            height={15}
+            alt="닫기"
+            onClick={onClose}
+          />
+        </div>
+
+        {/* 로딩 시 */}
+        {loading && (
           <div className="text-center text-lg">
-            <p>아바타 생성 중입니다... 🛠️</p>
-            <p className="mt-2 text-sm text-gray-500">잠시만 기다려주세요!</p>
+            <p>옷을 입고 있어요 👕</p>
+            <p className="mt-2 text-sm text-gray-500">
+              잠시만 기다려주세요! 최대 1분 소요됩니다
+            </p>
           </div>
-        ) : (
+        )}
+        {/* 에러 발생 시 */}
+        {error && (
+          <div className="text-center text-lg">
+            <p>아바타 생성에 실패했습니다. 😢</p>
+            <p className="mt-2 text-sm text-gray-500">다시 시도해주세요!</p>
+          </div>
+        )}
+        {/* try on 성공 시 */}
+        {!loading && !error && (
           <>
             {/* 상품 정보 */}
             <div className="absolute top-6 left-8">
@@ -54,16 +81,6 @@ const AvatarModal = ({ onClose }: AvatarModalProps) => {
               <div className="text-xl font-semibold mb-1">
                 {avatar.products[0]?.productName}
               </div>
-            </div>
-            {/* 닫기 버튼 */}
-            <div className="absolute top-6 right-8 cursor-pointer">
-              <Image
-                src="/images/common/close_icon.svg"
-                width={15}
-                height={15}
-                alt="닫기"
-                onClick={onClose}
-              />
             </div>
             {avatar.avatarImgUrl && (
               <div className="flex-1 flex items-center justify-center w-full h-full overflow-hidden">

--- a/src/hooks/useAvatarTryon.ts
+++ b/src/hooks/useAvatarTryon.ts
@@ -3,21 +3,25 @@ import { createAvatar } from "@/api/avatar";
 
 export const useAvatarTryon = () => {
   const setLoading = useAvatarStore((state) => state.setLoading);
-  const setAvatarImg = useAvatarStore((state) => state.setAvatarImg);
-  const addSelectedProductId = useAvatarStore((state) => state.addSelectedProductId);
-  const removeSelectedProductId = useAvatarStore((state) => state.removeSelectedProductId);
+  const setAvatarInfo = useAvatarStore((state) => state.setAvatarInfo);
+  const addSelectedProductId = useAvatarStore(
+    (state) => state.addSelectedProductId
+  );
+  const removeSelectedProductId = useAvatarStore(
+    (state) => state.removeSelectedProductId
+  );
 
   const tryOnProduct = async (productId: number) => {
     try {
       setLoading(true);
-      
+
       // API 호출로 아바타에 상품 착용
       const response = await createAvatar({ productId });
-      
+
       // 성공 시 전역 상태 업데이트
-      setAvatarImg(response.avatarImgUrl);
+      setAvatarInfo(response);
       addSelectedProductId(productId);
-      
+
       return response;
     } catch (error) {
       console.error("착용 중 오류 발생:", error);
@@ -30,16 +34,15 @@ export const useAvatarTryon = () => {
   const removeProduct = async (productId: number) => {
     try {
       setLoading(true);
-      
+
       // 상품 제거 API 호출 (실제 API 만들어야함)
       // const response = await removeAvatarProduct({ productId });
-      
+
       // 임시로 상품 ID만 제거
       removeSelectedProductId(productId);
-      
+
       // 실제로는 새로운 아바타 이미지를 받아와야 함
       // setAvatarImg(response.avatarImgUrl);
-      
     } catch (error) {
       console.error("상품 제거 중 오류 발생:", error);
       throw error;

--- a/src/stores/avatar-store.ts
+++ b/src/stores/avatar-store.ts
@@ -1,13 +1,14 @@
+import { AvatarResponse } from "@/types/avatar";
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
 // 타입 정의
 type AvatarState = {
-  avatarImg: string;
+  avatarInfo: AvatarResponse;
   selectedProductIds: number[];
   isLoading: boolean;
 
-  setAvatarImg: (img: string) => void;
+  setAvatarInfo: (info: AvatarResponse) => void;
   setSelectedProductIds: (ids: number[]) => void;
   addSelectedProductId: (id: number) => void;
   removeSelectedProductId: (id: number) => void;
@@ -18,11 +19,11 @@ type AvatarState = {
 export const useAvatarStore = create<AvatarState>()(
   persist(
     (set) => ({
-      avatarImg: "",
+      avatarInfo: { avatarId: 1, avatarImgUrl: "", products: [] },
       selectedProductIds: [],
       isLoading: false,
 
-      setAvatarImg: (img) => set({ avatarImg: img }),
+      setAvatarInfo: (info) => set({ avatarInfo: info }),
       setSelectedProductIds: (ids) => set({ selectedProductIds: ids }),
       addSelectedProductId: (id) =>
         set((state) => ({
@@ -39,7 +40,7 @@ export const useAvatarStore = create<AvatarState>()(
     {
       name: "avatar-storage", // localStorage 키 이름
       partialize: (state) => ({
-        avatarImg: state.avatarImg,
+        avatarInfo: state.avatarInfo,
         selectedProductIds: state.selectedProductIds,
       }),
     }

--- a/src/types/avatar.ts
+++ b/src/types/avatar.ts
@@ -1,10 +1,3 @@
-// 아바타 상품 정보 타입 (API 응답용)
-export type AvatarProductInfo = {
-  avatarImg: string;
-  productNames: string[];
-  avatarId: number;
-};
-
 type AvatarProduct = {
   productName: string;
   categoryName: string;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #13
---

## 📝 작업 내용

기존 avatar-store에서 저장하고 있던 try on 아바타 이미지 정보를 수정하였습니다.

try on 아바타 이미지 뿐 아니라, 착용한 제품의 정보 또한 전역적으로 사용하기 때문에
아래 `AvatarResponse` 타입으로 전역적으로 저장될 수 있도록 변경하였습니다.

```js
type AvatarProduct = {
  productName: string;
  categoryName: string;
};

export type AvatarResponse = {
  avatarId: number;
  avatarImgUrl: string;
  products: AvatarProduct[];
};
```

