### PR TITLE
[fix] 서버 데이터 필드명과 통일(avatarImg)

### DIFF
--- a/src/components/common/AvatarWearInfo.tsx
+++ b/src/components/common/AvatarWearInfo.tsx
@@ -12,8 +12,9 @@ const AvatarWearInfo = () => {
   const selectedProductIds = useAvatarStore(
     (state) => state.selectedProductIds
   );
-
   const isAvatarLoading = useAvatarStore((state) => state.isLoading);
+  const setAvatarLoading = useAvatarStore((state) => state.setLoading);
+
   const [isClosetLoading, setIsClosetLoading] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
 
@@ -23,6 +24,9 @@ const AvatarWearInfo = () => {
       try {
         const data = await fetchLatestAvatarInfo();
         setAvatarInfo(data); // 전역 상태 업데이트
+        console.log(avatarInfo);
+
+        setAvatarLoading(false);
       } catch (error) {
         console.error("아바타 정보 로드 실패", error);
       }
@@ -86,7 +90,7 @@ const AvatarWearInfo = () => {
       {/* 옷장에 추가 버튼 (우측 상단 고정) */}
       <button
         onClick={handleAddToCloset}
-        disabled={isClosetLoading || isAvatarLoading}
+        disabled={isAvatarLoading}
         className={`absolute top-4 right-4 z-10 px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
           isClosetLoading || isAvatarLoading
             ? "bg-gray-300 text-gray-500 cursor-not-allowed"
@@ -120,10 +124,10 @@ const AvatarWearInfo = () => {
 
       {/* 아바타 이미지 */}
       <div className="w-full flex justify-center mb-6 relative">
-        {avatarInfo.avatarImgUrl ? (
+        {avatarInfo.avatarImg ? (
           <div className="relative">
             <Image
-              src={avatarInfo.avatarImgUrl}
+              src={avatarInfo.avatarImg}
               alt="착장한 아바타"
               width={180}
               height={180}
@@ -153,7 +157,7 @@ const AvatarWearInfo = () => {
 
       {/* 착장 상품 리스트 */}
       <div>
-        {avatarInfo && avatarInfo.products.length > 0 ? (
+        {avatarInfo && avatarInfo.products && avatarInfo.products.length > 0 ? (
           <ul className="list-disc list-inside text-sm text-gray-700 space-y-1">
             {avatarInfo.products.map((product, idx) => (
               <li key={idx}>

--- a/src/components/ui/AvatarModal.tsx
+++ b/src/components/ui/AvatarModal.tsx
@@ -19,7 +19,7 @@ const AvatarModal = ({ onClose }: AvatarModalProps) => {
   const [error, setError] = useState(false);
   const [avatar, setAvatar] = useState<AvatarResponse>({
     avatarId: id,
-    avatarImgUrl: "",
+    avatarImg: "",
     products: [],
   });
 
@@ -82,10 +82,10 @@ const AvatarModal = ({ onClose }: AvatarModalProps) => {
                 {avatar.products[0]?.productName}
               </div>
             </div>
-            {avatar.avatarImgUrl && (
+            {avatar.avatarImg && (
               <div className="flex-1 flex items-center justify-center w-full h-full overflow-hidden">
                 <Image
-                  src={avatar.avatarImgUrl}
+                  src={avatar.avatarImg}
                   width={250}
                   height={250}
                   alt="생성된 아바타 이미지"

--- a/src/components/ui/ProductActionCard.tsx
+++ b/src/components/ui/ProductActionCard.tsx
@@ -52,8 +52,8 @@ const ProductActionCard = ({ data }: ProductActionCardProps) => {
         </div>
 
         <div className="space-y-2">
-          <WhiteButton text="장바구니" handleClick={handleAddCart} />
-          <BlackButton text="구매하기" handleClick={handleOrder} />
+          <WhiteButton text="찜하기" handleClick={handleAddCart} />
+          <BlackButton text="더보기" handleClick={handleOrder} />
         </div>
       </div>
     </div>

--- a/src/mock/avatar.ts
+++ b/src/mock/avatar.ts
@@ -3,7 +3,7 @@ import { AvatarResponse } from "@/types/avatar";
 export const dummyAvatar: AvatarResponse[] = [
   {
     avatarId: 1,
-    avatarImgUrl: "/images/dummy/ex10.png",
+    avatarImg: "/images/dummy/ex10.png",
     products: [
       {
         productName: "린넨 블루 셔츠",

--- a/src/stores/avatar-store.ts
+++ b/src/stores/avatar-store.ts
@@ -19,7 +19,7 @@ type AvatarState = {
 export const useAvatarStore = create<AvatarState>()(
   persist(
     (set) => ({
-      avatarInfo: { avatarId: 1, avatarImgUrl: "", products: [] },
+      avatarInfo: { avatarId: 1, avatarImg: "", products: [] },
       selectedProductIds: [],
       isLoading: false,
 

--- a/src/types/avatar.ts
+++ b/src/types/avatar.ts
@@ -9,6 +9,6 @@ export type AvatarRequest = {
 
 export type AvatarResponse = {
   avatarId: number;
-  avatarImgUrl: string;
+  avatarImg: string;
   products: AvatarProduct[];
 };


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/5ea56fe7-f22d-44d7-ab67-1669416902b7)

메인 페이지에서 avatarImg 필드가 서버 데이터 필드명과 상이하여 에러가 발생했습니다.
서버 데이터 필드명과 통일시켰습니다.