### PR TITLE
[feat/search] 헤더 검색 기능 구현

### DIFF
--- a/src/api/search.ts
+++ b/src/api/search.ts
@@ -8,9 +8,12 @@ export const fetchSearchSuggestions = async (
   query: string
 ): Promise<string[]> => {
   try {
-    const response = await axiosWithoutAuth().get("/api/products/suggestions", {
-      params: { query },
-    });
+    const response = await axiosWithoutAuth().get(
+      "/api/home/products/suggestions",
+      {
+        params: { query },
+      }
+    );
     return response.data;
   } catch (error) {
     console.warn("자동완성 요청 실패:", error);
@@ -25,7 +28,7 @@ export const fetchSearchResults = async (
   query: string
 ): Promise<SearchProductResponse> => {
   try {
-    const response = await axiosWithoutAuth().get("/api/products/search", {
+    const response = await axiosWithoutAuth().get("/api/home/products/search", {
       params: { query },
     });
     return response.data;

--- a/src/api/search.ts
+++ b/src/api/search.ts
@@ -1,31 +1,17 @@
-import { axiosWithAuth, axiosWithoutAuth } from "@/api";
+import { axiosWithoutAuth } from "@/api";
 import type { SearchProductResponse } from "@/types/product";
-
-const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080";
 
 /**
  * 자동완성 검색어 추천 요청
- * @param query 검색어
  */
 export const fetchSearchSuggestions = async (
   query: string
 ): Promise<string[]> => {
-  const token =
-    typeof window !== "undefined" ? localStorage.getItem("accessToken") : null;
-
   try {
-    if (token) {
-      const response = await axiosWithAuth().get("/api/products/suggestions", {
-        params: { query },
-      });
-      return response.data;
-    } else {
-      const response = await axiosWithoutAuth().get(
-        `/api/products/suggestions`,
-        { params: { query } }
-      );
-      return response.data;
-    }
+    const response = await axiosWithoutAuth().get("/api/products/suggestions", {
+      params: { query },
+    });
+    return response.data;
   } catch (error) {
     console.warn("자동완성 요청 실패:", error);
     return [];
@@ -33,27 +19,16 @@ export const fetchSearchSuggestions = async (
 };
 
 /**
- * 검색어에 해당하는 상품 목록 요청
- * @param query 검색어
+ * 검색 결과 요청
  */
 export const fetchSearchResults = async (
   query: string
 ): Promise<SearchProductResponse> => {
-  const token =
-    typeof window !== "undefined" ? localStorage.getItem("accessToken") : null;
-
   try {
-    if (token) {
-      const response = await axiosWithAuth().get("/api/products/search", {
-        params: { query },
-      });
-      return response.data;
-    } else {
-      const response = await axiosWithoutAuth().get("/api/products/search", {
-        params: { query },
-      });
-      return response.data;
-    }
+    const response = await axiosWithoutAuth().get("/api/products/search", {
+      params: { query },
+    });
+    return response.data;
   } catch (error) {
     console.warn("검색 결과 요청 실패:", error);
     return { products: [], totalCount: 0 };

--- a/src/api/search.ts
+++ b/src/api/search.ts
@@ -1,0 +1,61 @@
+import { axiosWithAuth, axiosWithoutAuth } from "@/api";
+import type { SearchProductResponse } from "@/types/product";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080";
+
+/**
+ * 자동완성 검색어 추천 요청
+ * @param query 검색어
+ */
+export const fetchSearchSuggestions = async (
+  query: string
+): Promise<string[]> => {
+  const token =
+    typeof window !== "undefined" ? localStorage.getItem("accessToken") : null;
+
+  try {
+    if (token) {
+      const response = await axiosWithAuth().get("/api/products/suggestions", {
+        params: { query },
+      });
+      return response.data;
+    } else {
+      const response = await axiosWithoutAuth().get(
+        `/api/products/suggestions`,
+        { params: { query } }
+      );
+      return response.data;
+    }
+  } catch (error) {
+    console.warn("자동완성 요청 실패:", error);
+    return [];
+  }
+};
+
+/**
+ * 검색어에 해당하는 상품 목록 요청
+ * @param query 검색어
+ */
+export const fetchSearchResults = async (
+  query: string
+): Promise<SearchProductResponse> => {
+  const token =
+    typeof window !== "undefined" ? localStorage.getItem("accessToken") : null;
+
+  try {
+    if (token) {
+      const response = await axiosWithAuth().get("/api/products/search", {
+        params: { query },
+      });
+      return response.data;
+    } else {
+      const response = await axiosWithoutAuth().get("/api/products/search", {
+        params: { query },
+      });
+      return response.data;
+    }
+  } catch (error) {
+    console.warn("검색 결과 요청 실패:", error);
+    return { products: [], totalCount: 0 };
+  }
+};

--- a/src/app/search/_components/SearchPageClient.tsx
+++ b/src/app/search/_components/SearchPageClient.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import { useEffect, useState } from "react";
+import { fetchSearchResults } from "@/api/search";
+import SearchResults from "@/app/search/_components/SearchResults";
+import type { SearchProductResponse } from "@/types/product";
+
+export default function SearchPageClient() {
+  const searchParams = useSearchParams();
+  const query = searchParams.get("query") || "";
+
+  const [results, setResults] = useState<SearchProductResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!query.trim()) return;
+
+    const fetch = async () => {
+      setLoading(true);
+      const res = await fetchSearchResults(query);
+      setResults(res);
+      setLoading(false);
+    };
+
+    fetch();
+  }, [query]);
+
+  return (
+    <main className="max-w-6xl mx-auto p-4">
+      <h2 className="text-lg font-semibold mb-4">"{query}" 검색 결과</h2>
+      {loading && <p>검색 중입니다...</p>}
+      {results && (
+        <SearchResults
+          products={results.products}
+          totalCount={results.totalCount}
+        />
+      )}
+    </main>
+  );
+}

--- a/src/app/search/_components/SearchResults.tsx
+++ b/src/app/search/_components/SearchResults.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import ProductCard from "@/components/common/ProductCard"; // 여기가 핵심!
+import type { ProductResponse } from "@/types/product";
+
+type Props = {
+  products: ProductResponse[];
+  totalCount: number;
+};
+
+export default function SearchResults({ products, totalCount }: Props) {
+  if (totalCount === 0) {
+    return (
+      <p className="text-center mt-6 text-gray-500">검색 결과가 없습니다.</p>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4 mt-6">
+      {products.map((product) => (
+        <ProductCard key={product.id} product={product} />
+      ))}
+    </div>
+  );
+}

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,0 +1,5 @@
+import SearchPageClient from "@/app/search/_components/SearchPageClient";
+
+export default function SearchPage() {
+  return <SearchPageClient />;
+}

--- a/src/components/common/SearchInput.tsx
+++ b/src/components/common/SearchInput.tsx
@@ -65,17 +65,21 @@ export default function SearchInput() {
         />
       </button>
 
-      {showSuggestions && suggestions.length > 0 && (
-        <ul className="absolute z-10 mt-2 w-full bg-white border rounded shadow">
-          {suggestions.map((s, idx) => (
-            <li
-              key={idx}
-              onClick={() => handleSearch(s)}
-              className="px-4 py-2 cursor-pointer hover:bg-gray-100"
-            >
-              {s}
-            </li>
-          ))}
+      {showSuggestions && (
+        <ul className="absolute z-10 mt-2 w-full bg-white border rounded shadow max-h-60 overflow-y-auto">
+          {suggestions.length > 0 ? (
+            suggestions.map((s, idx) => (
+              <li
+                key={idx}
+                onClick={() => handleSearch(s)}
+                className="px-4 py-2 cursor-pointer hover:bg-gray-100"
+              >
+                {s}
+              </li>
+            ))
+          ) : (
+            <li className="px-4 py-2 text-gray-500">검색 결과가 없습니다.</li>
+          )}
         </ul>
       )}
     </div>

--- a/src/components/common/SearchInput.tsx
+++ b/src/components/common/SearchInput.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import useDebounce from "@/hooks/useDebounce";
+import { fetchSearchSuggestions } from "@/api/search";
+import Image from "next/image";
+
+export default function SearchInput() {
+  const [inputValue, setInputValue] = useState("");
+  const [suggestions, setSuggestions] = useState<string[]>([]);
+  const [showSuggestions, setShowSuggestions] = useState(false);
+
+  const debounced = useDebounce(inputValue, 300);
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!debounced.trim()) {
+      setSuggestions([]);
+      return;
+    }
+
+    const fetch = async () => {
+      const data = await fetchSearchSuggestions(debounced);
+      setSuggestions(data);
+    };
+
+    fetch();
+  }, [debounced]);
+
+  const handleSearch = (keyword: string) => {
+    if (!keyword.trim()) return;
+    router.push(`/search?query=${encodeURIComponent(keyword)}`);
+    setShowSuggestions(false);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      handleSearch(inputValue);
+    }
+  };
+
+  return (
+    <div className="relative w-full h-10">
+      <input
+        type="text"
+        value={inputValue}
+        placeholder="검색어를 입력하세요"
+        onChange={(e) => {
+          setInputValue(e.target.value);
+          setShowSuggestions(true);
+        }}
+        onKeyDown={handleKeyDown}
+        className="w-full placeholder:text-slate-400 bg-[#f2f2f2] text-slate-700 text-sm border border-slate-200 rounded-md px-3 py-2 transition duration-300 ease focus:outline-none focus:border-slate-400 hover:border-slate-300 shadow-sm focus:shadow"
+      />
+      <button
+        className="absolute right-3 top-1.5"
+        onClick={() => handleSearch(inputValue)}
+      >
+        <Image
+          src="/images/common/search.svg"
+          width={25}
+          height={25}
+          alt="검색"
+        />
+      </button>
+
+      {showSuggestions && suggestions.length > 0 && (
+        <ul className="absolute z-10 mt-2 w-full bg-white border rounded shadow">
+          {suggestions.map((s, idx) => (
+            <li
+              key={idx}
+              onClick={() => handleSearch(s)}
+              className="px-4 py-2 cursor-pointer hover:bg-gray-100"
+            >
+              {s}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import Image from "next/image";
 import Link from "next/link";
+import SearchInput from "@/components/common/SearchInput";
 
 const Header = () => {
   return (
@@ -14,19 +15,7 @@ const Header = () => {
 
           {/* 검색창 */}
           <div className="relative flex items-center w-[70%] h-10">
-            <input
-              type="text"
-              placeholder="검색어를 입력하세요"
-              className="w-full placeholder:text-slate-400 bg-[#f2f2f2] text-slate-700 text-sm border border-slate-200 rounded-md px-3 py-2 transition duration-300 ease focus:outline-none focus:border-slate-400 hover:border-slate-300 shadow-sm focus:shadow"
-            />
-            <button className="absolute right-3">
-              <Image
-                src="/images/common/search.svg"
-                width={25}
-                height={25}
-                alt="logo"
-              />
-            </button>
+            <SearchInput />
           </div>
 
           {/* 옷장, 장바구니, 마이페이지 */}

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,0 +1,14 @@
+import { useEffect, useState } from "react";
+
+const useDebounce = (value: string, delay: number) => {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedValue(value), delay);
+    return () => clearTimeout(timer);
+  }, [value, delay]);
+
+  return debouncedValue;
+};
+
+export default useDebounce;

--- a/src/types/product.ts
+++ b/src/types/product.ts
@@ -54,3 +54,9 @@ export const initialProductResponse: ProductResponse[] = [
     categoryName: "",
   },
 ];
+
+// 검색 결과 응답 타입
+export type SearchProductResponse = {
+  products: ProductResponse[];
+  totalCount: number;
+};


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #49

---

## 📝 작업 내용

> 헤더의 검색창에 검색이 되도록 구현하였다.  
> 입력한 query 값이 제품명(productName) 또는 브랜드명(brand)에 포함된 경우,
해당 상품의 productName을 자동완성 키워드로 추천해준다.  

> useDebounce 훅 생성해서 성능을 개선하였다.  
> useDebounce를 적용함으로써, 요청이 들어오고 일정 시간을 기다린 후 요청을 수행한다.  
>> 한글자를 타이핑할때마다 검색하는 문제가 있기 때문이다. (성능이슈)   

---

### 📷 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/9a1f0204-5364-4bcd-b761-3ec4b9670c35)

![image](https://github.com/user-attachments/assets/b79febd7-6796-4275-ac60-e386234e3c05)
