### PR TITLE
[fix/story] 스토리 착장 정보 할인가 계산 로직 적용

### DIFF
--- a/src/components/ui/ProductActionCard.tsx
+++ b/src/components/ui/ProductActionCard.tsx
@@ -13,7 +13,6 @@ type ProductActionCardProps = {
 };
 
 const ProductActionCard = ({ data }: ProductActionCardProps) => {
-  const isDiscounted = data.price != data.sale;
   const router = useRouter();
   const { toggleWishlist } = useWishlist(data.liked, data.id);
 
@@ -28,6 +27,14 @@ const ProductActionCard = ({ data }: ProductActionCardProps) => {
     console.log("상품 정보:", data);
     router.push(`/detail/${data.id}`);
   };
+
+  const isDiscounted = data.sale > 0; // 할인율이 0보다 크면 할인 중
+  const discountedPrice = isDiscounted
+    ? Math.round(data.price * (1 - data.sale / 100))
+    : data.price;
+
+  const formattedPrice = data.price.toLocaleString();
+  const formattedDiscountedPrice = discountedPrice.toLocaleString();
 
   return (
     <div className="flex h-60 items-stretch gap-4 text-sm text-black hover:opacity-90">
@@ -50,11 +57,11 @@ const ProductActionCard = ({ data }: ProductActionCardProps) => {
           <div className="my-2">
             {isDiscounted && (
               <div className="text-gray-400 line-through text-base">
-                {data.price.toLocaleString()}원
+                {formattedPrice}원
               </div>
             )}
             <div className="font-semibold text-xl">
-              {data.sale.toLocaleString()}원
+              {formattedDiscountedPrice}원
             </div>
           </div>
         </div>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #6 

---

## 📝 작업 내용

> 현재 스토리 기능에서 착장 정보를 누르면 할인가가 제대로 적용이 되지 않는 문제가 있었다. 
> 스토리 페이지의 할인가가 잘 적용되도록 수정해주었다.  

---

### 📷 스크린샷 (선택)

<img width="1077" alt="image" src="https://github.com/user-attachments/assets/26be292f-81e7-4048-8506-5bf37d281d42" />

<img width="1087" alt="image" src="https://github.com/user-attachments/assets/5defdac4-c1e8-40be-ab57-1ae7c3e4b13a" />
