### PR TITLE
[refactor/search] 검색 기능 개선

### DIFF
--- a/src/components/common/SearchInput.tsx
+++ b/src/components/common/SearchInput.tsx
@@ -52,9 +52,9 @@ export default function SearchInput() {
 
   const handleSearch = (keyword: string) => {
     if (!keyword.trim()) return;
-    router.push(`/search?query=${encodeURIComponent(keyword)}`);
+    setInputValue(keyword); // 선택한 텍스트를 검색창에 유지
     setShowSuggestions(false);
-    setInputValue(""); // (검색 실행 후) 입력창 초기화
+    router.push(`/search?query=${encodeURIComponent(keyword)}`);
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {

--- a/src/components/common/SearchInput.tsx
+++ b/src/components/common/SearchInput.tsx
@@ -2,6 +2,7 @@
 
 import { useRef, useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
+import { useSearchParams } from "next/navigation";
 import useDebounce from "@/hooks/useDebounce";
 import { fetchSearchSuggestions } from "@/api/search";
 import Image from "next/image";
@@ -17,6 +18,16 @@ export default function SearchInput() {
   const debounced = useDebounce(inputValue, 300);
   const router = useRouter();
   const wrapperRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const searchParams = useSearchParams();
+  const query = searchParams.get("query");
+
+  useEffect(() => {
+    if (query !== null) {
+      setInputValue(query);
+    }
+  }, [query]);
 
   useEffect(() => {
     if (!debounced.trim()) {
@@ -54,6 +65,7 @@ export default function SearchInput() {
     if (!keyword.trim()) return;
     setInputValue(keyword); // 선택한 텍스트를 검색창에 유지
     setShowSuggestions(false);
+    inputRef.current?.blur(); // 검색 후 커서 제거
     router.push(`/search?query=${encodeURIComponent(keyword)}`);
   };
 
@@ -66,6 +78,7 @@ export default function SearchInput() {
   return (
     <div className="relative w-full h-10" ref={wrapperRef}>
       <input
+        ref={inputRef}
         type="text"
         value={inputValue}
         placeholder="검색어를 입력하세요"

--- a/src/components/common/SearchInput.tsx
+++ b/src/components/common/SearchInput.tsx
@@ -14,6 +14,7 @@ export default function SearchInput() {
   const [selectedIndex, setSelectedIndex] = useState(-1); // -1은 아무것도 선택 안함
   /* 현재 값이 입력이 완료된 상태인지 아닌지를 나타내주는 속성 */
   const [isComposing, setIsComposing] = useState(false);
+  const [lastCommittedInput, setLastCommittedInput] = useState("");
 
   const debounced = useDebounce(inputValue, 300);
   const router = useRouter();
@@ -26,6 +27,7 @@ export default function SearchInput() {
   useEffect(() => {
     if (query !== null) {
       setInputValue(query);
+      setLastCommittedInput(query);
     }
   }, [query]);
 
@@ -61,8 +63,27 @@ export default function SearchInput() {
     };
   }, []);
 
+  /* 키보드 이벤트 핸들러 추가 (ESC 키를 누르면 검색창 닫기) */
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        inputRef.current?.blur();
+        setInputValue(lastCommittedInput);
+        setShowSuggestions(false);
+        setSelectedIndex(-1);
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [lastCommittedInput]); // 최신 검색어 감지
+
   const handleSearch = (keyword: string) => {
     if (!keyword.trim()) return;
+
+    setLastCommittedInput(keyword); // 직전 검색어 저장
     setInputValue(keyword); // 선택한 텍스트를 검색창에 유지
     setShowSuggestions(false);
     inputRef.current?.blur(); // 검색 후 커서 제거

--- a/src/components/common/SearchInput.tsx
+++ b/src/components/common/SearchInput.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { useSearchParams } from "next/navigation";
 import useDebounce from "@/hooks/useDebounce";
 import { fetchSearchSuggestions } from "@/api/search";
+import { usePathname } from "next/navigation";
 import Image from "next/image";
 
 export default function SearchInput() {
@@ -20,6 +21,7 @@ export default function SearchInput() {
   const router = useRouter();
   const wrapperRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const pathname = usePathname();
 
   const searchParams = useSearchParams();
   const query = searchParams.get("query");
@@ -30,6 +32,14 @@ export default function SearchInput() {
       setLastCommittedInput(query);
     }
   }, [query]);
+
+  useEffect(() => {
+    if (pathname !== "/search") {
+      // search 페이지가 아니면 검색어 초기화
+      setInputValue("");
+      setLastCommittedInput("");
+    }
+  }, [pathname]);
 
   useEffect(() => {
     if (!debounced.trim()) {

--- a/src/components/common/SearchInput.tsx
+++ b/src/components/common/SearchInput.tsx
@@ -11,6 +11,8 @@ export default function SearchInput() {
   const [suggestions, setSuggestions] = useState<string[]>([]);
   const [showSuggestions, setShowSuggestions] = useState(false);
   const [selectedIndex, setSelectedIndex] = useState(-1); // -1은 아무것도 선택 안함
+  /* 현재 값이 입력이 완료된 상태인지 아닌지를 나타내주는 속성 */
+  const [isComposing, setIsComposing] = useState(false);
 
   const debounced = useDebounce(inputValue, 300);
   const router = useRouter();
@@ -56,8 +58,8 @@ export default function SearchInput() {
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Enter") {
-      handleSearch(inputValue);
+    if (e.key === "Enter" && !isComposing) {
+      handleSearch(e.currentTarget.value); // 사용자가 입력한 최신 값을 그대로 검색에 넘겨줌
     }
   };
 
@@ -70,6 +72,11 @@ export default function SearchInput() {
         onChange={(e) => {
           setInputValue(e.target.value);
           setShowSuggestions(true);
+        }}
+        onCompositionStart={() => setIsComposing(true)}
+        onCompositionEnd={(e) => {
+          setIsComposing(false);
+          setInputValue(e.currentTarget.value); // 조합 끝난 후 값 다시 세팅
         }}
         onKeyDown={handleKeyDown}
         className="w-full placeholder:text-slate-400 bg-[#f2f2f2] text-slate-700 text-sm border border-slate-200 rounded-md px-3 py-2 transition duration-300 ease focus:outline-none focus:border-slate-400 hover:border-slate-300 shadow-sm focus:shadow"


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #60 

---

## 📝 작업 내용

> 검색 버튼을 클릭하면 검색어 입력이 잘 되는데, `Enter`를 치면 끝에만 인식이 되어 검색이 되는 문제가 있었다. 이는 `composition` 상태를 추적해 조합 중일 땐 `Enter` 이벤트를 무시하도록 처리하여 해결하였다.  
> 검색하고 결과가 출력되면 검색창에 계속 유지되도록 해주었다.  
> 검색 완료 후 포커스 제거를 해주었고, `/search` 페이지에서 뒤로가기했을땐, 이전 검색어가 계속 유지되도록 하였고, `/search` 페이지가 아닌 다른 페이지로 이동하면 자동으로 검색어가 초기화되도록 해주었다.  
> 검색창 포커싱 후 `ESC` 키를 누르면 검색창이 닫히도록 해주었다.

---

### 📷 스크린샷  

<img width="2322" height="894" alt="image" src="https://github.com/user-attachments/assets/41c3e896-4ae9-4ad0-8794-1f3ad8eb849f" />  

<img width="719" height="597" alt="image" src="https://github.com/user-attachments/assets/7b280b90-f640-4da6-a401-27dcf50f74c4" />
