### PR TITLE
[refactor/search] 상품 검색 결과 무한 스크롤 적용

### DIFF
--- a/src/api/search.ts
+++ b/src/api/search.ts
@@ -25,11 +25,13 @@ export const fetchSearchSuggestions = async (
  * 검색 결과 요청
  */
 export const fetchSearchResults = async (
-  query: string
+  query: string,
+  page: number = 0,
+  size: number = 10
 ): Promise<SearchProductResponse> => {
   try {
     const response = await axiosWithoutAuth().get("/api/home/products/search", {
-      params: { query },
+      params: { query, page, size },
     });
     return response.data;
   } catch (error) {

--- a/src/app/search/_components/SearchPageClient.tsx
+++ b/src/app/search/_components/SearchPageClient.tsx
@@ -1,39 +1,77 @@
 "use client";
 
+import React, { useEffect, useState, useCallback } from "react";
 import { useSearchParams } from "next/navigation";
-import { useEffect, useState } from "react";
-import { fetchSearchResults } from "@/api/search";
 import SearchResults from "@/app/search/_components/SearchResults";
-import type { SearchProductResponse } from "@/types/product";
+import type { ProductResponse } from "@/types/product";
+import { useIntersectionObserver } from "@/hooks/useIntersectionObserver";
+import { useInfiniteSearchProducts } from "@/hooks/useInfiniteSearchProducts";
 
 export default function SearchPageClient() {
   const searchParams = useSearchParams();
   const query = searchParams.get("query") || "";
 
-  const [results, setResults] = useState<SearchProductResponse | null>(null);
-  const [loading, setLoading] = useState(false);
+  const {
+    data,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    status,
+    error,
+  } = useInfiniteSearchProducts(query);
 
-  useEffect(() => {
-    if (!query.trim()) return;
+  const observerRef = useIntersectionObserver({
+    onIntersect: () => {
+      if (hasNextPage && !isFetchingNextPage) {
+        fetchNextPage();
+      }
+    },
+    enabled: !!hasNextPage,
+  });
 
-    const fetch = async () => {
-      setLoading(true);
-      const res = await fetchSearchResults(query);
-      setResults(res);
-      setLoading(false);
-    };
+  if (status === "pending" && !data) {
+    return (
+      <main className="max-w-6xl mx-auto p-4">
+        <h2 className="text-lg font-semibold mb-4">"{query}" 검색 결과</h2>
+        <p className="text-center mt-6 text-gray-500">검색 중입니다...</p>
+      </main>
+    );
+  }
 
-    fetch();
-  }, [query]);
+  // 에러 발생 시 메시지
+  if (status === "error") {
+    return (
+      <main className="max-w-6xl mx-auto p-4">
+        <h2 className="text-lg font-semibold mb-4">"{query}" 검색 결과</h2>
+        <p className="text-center mt-6 text-red-500">
+          상품을 불러오는 데 실패했어요: {error?.message || "알 수 없는 에러"}
+        </p>
+      </main>
+    );
+  }
+
+  const allProducts: ProductResponse[] =
+    data?.pages.flatMap((page) => page.products) || [];
+
+  const totalCount = data?.pages[0]?.totalCount || 0;
 
   return (
     <main className="max-w-6xl mx-auto p-4">
       <h2 className="text-lg font-semibold mb-4">"{query}" 검색 결과</h2>
-      {loading && <p>검색 중입니다...</p>}
-      {results && (
+
+      {/* 검색 결과가 없을 때 메시지 */}
+      {allProducts.length === 0 && !isFetchingNextPage && query.trim() && (
+        <p className="text-center mt-6 text-gray-500">검색 결과가 없습니다.</p>
+      )}
+
+      {/* 제품이 있을 때만 SearchResults 컴포넌트 렌더링 */}
+      {allProducts.length > 0 && (
         <SearchResults
-          products={results.products}
-          totalCount={results.totalCount}
+          products={allProducts}
+          totalCount={totalCount} // 전체 결과 개수
+          observerRef={observerRef}
+          hasNextPage={!!hasNextPage} // 다음 페이지 존재 여부
+          isFetchingNextPage={isFetchingNextPage}
         />
       )}
     </main>

--- a/src/app/search/_components/SearchResults.tsx
+++ b/src/app/search/_components/SearchResults.tsx
@@ -1,13 +1,22 @@
 import React from "react";
-import ProductCard from "@/components/common/ProductCard"; // 여기가 핵심!
+import ProductCard from "@/components/common/ProductCard";
 import type { ProductResponse } from "@/types/product";
 
 type Props = {
   products: ProductResponse[];
   totalCount: number;
+  observerRef?: React.Ref<HTMLDivElement>;
+  hasNextPage?: boolean;
+  isFetchingNextPage?: boolean;
 };
 
-export default function SearchResults({ products, totalCount }: Props) {
+export default function SearchResults({
+  products,
+  totalCount,
+  observerRef,
+  hasNextPage,
+  isFetchingNextPage,
+}: Props) {
   if (totalCount === 0) {
     return (
       <p className="text-center mt-6 text-gray-500">검색 결과가 없습니다.</p>
@@ -16,9 +25,26 @@ export default function SearchResults({ products, totalCount }: Props) {
 
   return (
     <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4 mt-6">
-      {products.map((product) => (
-        <ProductCard key={product.id} product={product} />
-      ))}
+      {products.map((product, index) => {
+        // 현재 아이템이 마지막 아이템인지 확인
+        const isLastItem = index === products.length - 1;
+
+        return (
+          // 마지막 아이템이고 다음 페이지가 있을 경우에만 observerRef를 연결
+          <div
+            key={product.id}
+            ref={isLastItem && hasNextPage ? observerRef : undefined}
+          >
+            <ProductCard product={product} />
+          </div>
+        );
+      })}
+      {/* 다음 페이지를 불러오는 중일 때 로딩 인디케이터 표시 */}
+      {isFetchingNextPage && (
+        <div className="col-span-full text-center text-sm text-gray-500 mt-4">
+          다음 상품 불러오는 중...
+        </div>
+      )}
     </div>
   );
 }

--- a/src/hooks/useInfiniteSearchProducts.ts
+++ b/src/hooks/useInfiniteSearchProducts.ts
@@ -1,0 +1,38 @@
+import { useInfiniteQuery, InfiniteData } from "@tanstack/react-query";
+import { fetchSearchResults } from "@/api/search";
+import { SearchProductResponse } from "@/types/product";
+
+const SEARCH_PAGE_SIZE = 10;
+
+/**
+ * 무한 스크롤 검색 결과를 위한 React Query 훅
+ * @param query
+ */
+export const useInfiniteSearchProducts = (query: string) => {
+  return useInfiniteQuery<
+    SearchProductResponse,
+    Error,
+    InfiniteData<SearchProductResponse, number>,
+    string[],
+    number
+  >({
+    queryKey: ["searchProducts", query],
+    queryFn: async ({ pageParam = 0 }) => {
+      return await fetchSearchResults(query, pageParam, SEARCH_PAGE_SIZE);
+    },
+    getNextPageParam: (lastPage, allPages) => {
+      const loadedCount = allPages.reduce(
+        (acc, page) => acc + page.products.length,
+        0
+      );
+      if (loadedCount < lastPage.totalCount) {
+        return allPages.length;
+      }
+      return undefined;
+    },
+    initialPageParam: 0,
+    enabled: !!query.trim(),
+    staleTime: 1000 * 60 * 5,
+    gcTime: 1000 * 60 * 10,
+  });
+};


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #60

---

## 📝 작업 내용

> 검색 결과가 10개로 제한되던 문제 해결 및 모든 관련 상품 탐색 가능하도록 개선  
> useInfiniteSearchproducts 훅을 통해 React Query 기반 무한 로딩 도입
> useIntersectionObserver를 활용하여 스크롤 시 자동 데이터 로드를 구현
> SearchPageClient와 SearchResults 컴포넌트 업데이트 및 타입 오류를 수정

---

### 결과

https://github.com/user-attachments/assets/09149dd0-e05c-41ac-9148-68617805d752

