### PR TITLE
[style/DetailPage] 상세 페이지 UI 개선

### DIFF
--- a/src/app/detail/[id]/_components/BottomActionButtons.tsx
+++ b/src/app/detail/[id]/_components/BottomActionButtons.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import Image from "next/image";
+import WhiteButton from "@/components/common/WhiteButton";
+import BlackButton from "@/components/common/BlackButton";
+
+type Props = {
+  isWished: boolean;
+  toggleWishlist: () => void;
+  wishlistCount: number;
+  isOutOfStock: boolean;
+  isLoading: boolean;
+  onAddCart: () => void;
+  onOrder: () => void;
+  isMobile: boolean;
+};
+
+export default function BottomActionButtons({
+  isWished,
+  toggleWishlist,
+  wishlistCount,
+  isOutOfStock,
+  isLoading,
+  onAddCart,
+  onOrder,
+  isMobile,
+}: Props) {
+  return (
+    <div className={`flex ${isMobile ? "gap-4" : "gap-6"}`}>
+      {/* 위시리스트 하트 */}
+      <div
+        className="flex flex-col items-center gap-1 cursor-pointer"
+        onClick={toggleWishlist}
+      >
+        <Image
+          src={
+            isWished
+              ? "/images/common/red_heart.svg"
+              : "/images/common/heart.svg"
+          }
+          width={24}
+          height={24}
+          alt="heart"
+        />
+        <p className="text-xs">{wishlistCount.toLocaleString()}</p>
+      </div>
+
+      {/* 장바구니 버튼 */}
+      <WhiteButton
+        text={isOutOfStock ? "품절" : isLoading ? "추가 중..." : "장바구니"}
+        handleClick={onAddCart}
+        disabled={isLoading || isOutOfStock}
+      />
+
+      {/* 구매하기 버튼 */}
+      <BlackButton
+        text={isOutOfStock ? "품절" : "구매하기"}
+        handleClick={onOrder}
+        disabled={isOutOfStock}
+      />
+    </div>
+  );
+}

--- a/src/app/detail/[id]/_components/DetailClient.tsx
+++ b/src/app/detail/[id]/_components/DetailClient.tsx
@@ -38,23 +38,38 @@ const DetailClient = ({ productId }: DetailClientProps) => {
   return (
     <>
       {loading && <Spinner />}
-      <div className="w-full flex justify-between">
-        {/* 좌측 상품 이미지 등 상세정보 */}
-        <div className="w-[65%]">
+
+      {/* 모바일 전용 : ProductDetailInfo를 MainImg 바로 아래에 위치 */}
+      <div className="md:hidden">
+        <DetailMainImg images={data.images} productId={productId} />
+        <ProductDetailInfo data={data} />
+        <DetailRecommand productId={productId} />
+        {data.images
+          .slice(4)
+          .filter((img) => img && img.trim() !== "")
+          .map((img, idx) => (
+            <DetailInfo key={idx} image={img} index={idx} />
+          ))}
+      </div>
+
+      {/* 데스크탑 전용 : 기존 레이아웃 유지 */}
+      <div className="w-full flex flex-col md:flex-row justify-between">
+        {/* 좌측: 메인 이미지 + 추천 + 상세 이미지 */}
+        <div className="w-full md:w-2/3 md:pr-6">
           <DetailMainImg images={data.images} productId={productId} />
           <DetailRecommand productId={Number(productId)} />
 
           {/* img5 배열의 모든 상세 이미지 표시 */}
-          {data.images.slice(4)
-              .filter((img) => img && img.trim() !== '')
-              .map((img, idx) => (
-                  <DetailInfo key={idx} image={img} index={idx} />
-              ))
-          }
+          {data.images
+            .slice(4)
+            .filter((img) => img && img.trim() !== "")
+            .map((img, idx) => (
+              <DetailInfo key={idx} image={img} index={idx} />
+            ))}
         </div>
 
         {/* 우측 상품 장바구니/구매하기 창 */}
-        <div className="bg-white w-[35%] min-h-screen h-screen fixed right-0 top-[15vh] bottom-0 overflow-y-auto shadow-md">
+        <div className="w-full md:w-1/3 md:min-h-screen md:h-screen md:fixed md:right-0 md:top-[15vh] md:bottom-0 md:overflow-y-auto md:shadow-md md:bg-white">
           <ProductDetailInfo data={data} />
         </div>
       </div>

--- a/src/app/detail/[id]/_components/DetailClient.tsx
+++ b/src/app/detail/[id]/_components/DetailClient.tsx
@@ -8,6 +8,7 @@ import { getProductDetail } from "@/api/productDetail";
 import { useEffect, useState } from "react";
 import Spinner from "@/components/common/Spinner";
 import { initialProductDetail } from "@/types/productDetail";
+import { useIsMobile } from "@/hooks/useMediaQuery";
 
 type DetailClientProps = {
   productId: number;
@@ -16,6 +17,7 @@ type DetailClientProps = {
 const DetailClient = ({ productId }: DetailClientProps) => {
   const [data, setData] = useState(initialProductDetail);
   const [loading, setLoading] = useState(true);
+  const isMobile = useIsMobile();
 
   const fetchData = async () => {
     try {
@@ -38,41 +40,41 @@ const DetailClient = ({ productId }: DetailClientProps) => {
   return (
     <>
       {loading && <Spinner />}
-
       {/* 모바일 전용 : ProductDetailInfo를 MainImg 바로 아래에 위치 */}
-      <div className="md:hidden">
-        <DetailMainImg images={data.images} productId={productId} />
-        <ProductDetailInfo data={data} />
-        <DetailRecommand productId={productId} />
-        {data.images
-          .slice(4)
-          .filter((img) => img && img.trim() !== "")
-          .map((img, idx) => (
-            <DetailInfo key={idx} image={img} index={idx} />
-          ))}
-      </div>
-
-      {/* 데스크탑 전용 : 기존 레이아웃 유지 */}
-      <div className="w-full flex flex-col md:flex-row justify-between">
-        {/* 좌측: 메인 이미지 + 추천 + 상세 이미지 */}
-        <div className="w-full md:w-2/3 md:pr-6">
+      {isMobile ? (
+        <>
           <DetailMainImg images={data.images} productId={productId} />
-          <DetailRecommand productId={Number(productId)} />
-
-          {/* img5 배열의 모든 상세 이미지 표시 */}
+          <ProductDetailInfo data={data} />
+          <DetailRecommand productId={productId} />
           {data.images
             .slice(4)
             .filter((img) => img && img.trim() !== "")
             .map((img, idx) => (
               <DetailInfo key={idx} image={img} index={idx} />
             ))}
-        </div>
+        </>
+      ) : (
+        <div className="w-full flex flex-col md:flex-row justify-between">
+          {/* 좌측: 메인 이미지 + 추천 + 상세 이미지 */}
+          <div className="w-full md:w-[65%] md:pr-6">
+            <DetailMainImg images={data.images} productId={productId} />
+            <DetailRecommand productId={Number(productId)} />
 
-        {/* 우측 상품 장바구니/구매하기 창 */}
-        <div className="w-full md:w-1/3 md:min-h-screen md:h-screen md:fixed md:right-0 md:top-[15vh] md:bottom-0 md:overflow-y-auto md:shadow-md md:bg-white">
-          <ProductDetailInfo data={data} />
+            {/* img5 배열의 모든 상세 이미지 표시 */}
+            {data.images
+              .slice(4)
+              .filter((img) => img && img.trim() !== "")
+              .map((img, idx) => (
+                <DetailInfo key={idx} image={img} index={idx} />
+              ))}
+          </div>
+
+          {/* 우측 상품 장바구니/구매하기 창 */}
+          <div className="w-full md:w-[35%] md:min-h-screen md:h-screen md:fixed md:right-0 md:top-[15vh] md:bottom-0 md:overflow-y-auto md:shadow-md md:bg-white">
+            <ProductDetailInfo data={data} />
+          </div>
         </div>
-      </div>
+      )}
     </>
   );
 };

--- a/src/app/detail/[id]/_components/DetailInfo.tsx
+++ b/src/app/detail/[id]/_components/DetailInfo.tsx
@@ -8,11 +8,11 @@ type DetailInfoProps = {
 
 const DetailInfo = ({ image, index = 0 }: DetailInfoProps) => {
   // 이미지 유효성 검사
-  if (!image || image.trim() === ''){
+  if (!image || image.trim() === "") {
     return null;
   }
   return (
-    <div className="w-full relative my-10">
+    <div className="w-full relative my-6 md:my-10">
       <Image
         src={image}
         alt={`상품 상세 정보 ${index + 1}`} // index 사용
@@ -22,7 +22,7 @@ const DetailInfo = ({ image, index = 0 }: DetailInfoProps) => {
         className="w-full h-auto"
         onError={(e) => {
           console.error(`상세 이미지 로드 실패: ${image}`);
-          e.currentTarget.style.display = 'none';
+          e.currentTarget.style.display = "none";
         }}
       />
     </div>

--- a/src/app/detail/[id]/_components/DetailMainImg.tsx
+++ b/src/app/detail/[id]/_components/DetailMainImg.tsx
@@ -84,7 +84,7 @@ const DetailMainImg = ({ images, productId }: DetailMainImgProps) => {
         </Swiper>
         {/* 아바타 버튼을 Swiper 외부로 이동 */}
         <div
-          className="absolute top-4 right-4 z-10 cursor-pointer"
+          className="absolute top-4 right-4 z-5 cursor-pointer"
           onClick={handleAvatarClick}
         >
           <Image

--- a/src/app/detail/[id]/_components/DetailMainImg.tsx
+++ b/src/app/detail/[id]/_components/DetailMainImg.tsx
@@ -89,8 +89,8 @@ const DetailMainImg = ({ images, productId }: DetailMainImgProps) => {
         >
           <Image
             src="/images/common/avatar.svg"
-            width={50}
-            height={50}
+            width={35}
+            height={35}
             alt="입어보기"
           />
         </div>

--- a/src/app/detail/[id]/_components/DetailOrderOptions.tsx
+++ b/src/app/detail/[id]/_components/DetailOrderOptions.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import React from "react";
+
+type Variant = {
+  variantId: number;
+  color: string;
+  size: string;
+  quantity: number;
+};
+
+type OrderData = {
+  color: string;
+  size: string;
+  quantity: number;
+};
+
+type OrderOptionsProps = {
+  isMobile: boolean;
+  orderData: OrderData;
+  variantList: Variant[];
+  calculateTotal: () => number;
+  handleColorChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
+  handleSizeChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
+  handleQuantityChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  increaseQuantity: () => void;
+  decreaseQuantity: () => void;
+  setShowOptions?: (value: boolean) => void;
+};
+
+const OrderOptions = ({
+  isMobile,
+  orderData,
+  variantList,
+  calculateTotal,
+  handleColorChange,
+  handleSizeChange,
+  handleQuantityChange,
+  increaseQuantity,
+  decreaseQuantity,
+  setShowOptions,
+}: OrderOptionsProps) => {
+  const uniqueColors = [...new Set(variantList.map((v) => v.color))];
+  const sizesForSelectedColor = variantList.filter(
+    (v) => v.color === orderData.color
+  );
+
+  return (
+    <>
+      {/* 모바일에서만 핸들 영역 표시 */}
+      {isMobile && (
+        <div
+          className="flex items-center justify-center py-2 cursor-pointer"
+          onClick={() => setShowOptions?.(false)}
+          data-mds="BottomSheetHandleArea"
+        >
+          <div
+            className="h-1 w-9 rounded-[10px] bg-gray-300"
+            data-mds="BottomSheetHandle"
+          ></div>
+        </div>
+      )}
+
+      {/* 컬러 선택 */}
+      <div>
+        <label className="block text-sm font-medium mb-1">컬러</label>
+        <select
+          value={orderData.color}
+          onChange={handleColorChange}
+          className="w-full border border-gray-300 px-2 py-1.5 rounded-md text-sm md:px-3 md:py-2"
+        >
+          {uniqueColors.map((color) => (
+            <option key={color} value={color}>
+              {color}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* 사이즈 선택 */}
+      <div>
+        <label className="block text-sm font-medium mb-1">사이즈</label>
+        <select
+          value={orderData.size}
+          onChange={handleSizeChange}
+          className="w-full border border-gray-300 px-2 py-1.5 rounded-md text-sm md:px-3 md:py-2"
+        >
+          <option value="" disabled>
+            사이즈를 선택해주세요
+          </option>
+          {sizesForSelectedColor.map((variant, index) => (
+            <option key={index} value={variant.size}>
+              {variant.size}{" "}
+              {variant.quantity === 0
+                ? "(품절)"
+                : `(재고: ${variant.quantity}개)`}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* 수량 및 총 금액 */}
+      <div className="flex items-end justify-between mt-2">
+        <div>
+          <label className="block text-sm font-medium mb-1">수량</label>
+          <div className="flex items-center gap-1">
+            <button
+              onClick={decreaseQuantity}
+              className="w-7 h-7 border border-stone-300 bg-gray-100 rounded md:w-8 md:h-8"
+            >
+              -
+            </button>
+            <input
+              type="number"
+              min={1}
+              value={orderData.quantity}
+              onChange={handleQuantityChange}
+              className="w-10 h-7 border border-stone-300 text-center text-sm rounded md:w-12 md:h-8"
+            />
+            <button
+              onClick={increaseQuantity}
+              className="w-7 h-7 border border-stone-300 bg-gray-100 rounded md:w-8 md:h-8"
+            >
+              +
+            </button>
+          </div>
+        </div>
+        <div className="text-right text-lg font-semibold">
+          {calculateTotal().toLocaleString()}원
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default OrderOptions;

--- a/src/app/detail/[id]/_components/DetailRecommand.tsx
+++ b/src/app/detail/[id]/_components/DetailRecommand.tsx
@@ -35,8 +35,8 @@ const DetailRecommand = ({ productId }: DetailRecommandProps) => {
   }, []);
 
   return (
-    <div className="bg-gray-50 py-6 px-4 rounded-xl mt-8">
-      <div className="text-base text-neutral-600 mb-4 p-2">
+    <div className="bg-gray-50 py-4 px-3 rounded-lg mt-6 md:py-6 md:px-4 md:rounded-xl md:mt-8">
+      <div className="text-sm text-neutral-600 mb-3 md:text-base md:mb-4 md:p-2">
         같이 볼만한 상품
       </div>
 

--- a/src/app/detail/[id]/_components/DetailUserForm.tsx
+++ b/src/app/detail/[id]/_components/DetailUserForm.tsx
@@ -1,15 +1,14 @@
 "use client";
 
-import BlackButton from "@/components/common/BlackButton";
 import Tag from "@/components/common/Tag";
-import WhiteButton from "@/components/common/WhiteButton";
 import { useWishlist } from "@/hooks/useWishlist";
 import { useCart } from "@/hooks/useCart";
 import { ProductDetailResponse } from "@/types/productDetail";
-import Image from "next/image";
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { useIsMobile } from "@/hooks/useMediaQuery";
+import OrderOptions from "@/app/detail/[id]/_components/DetailOrderOptions";
+import BottomActionButtons from "@/app/detail/[id]/_components/BottomActionButtons";
 
 type ProductDetailInfoProps = {
   data: ProductDetailResponse;
@@ -182,96 +181,6 @@ const ProductDetailInfo = ({ data }: ProductDetailInfoProps) => {
     return currentVariant?.quantity === 0;
   };
 
-  // 옵션 선택 및 수량 조절 UI를 별도의 함수로 분리
-  const renderOptionsAndQuantity = () => (
-    <>
-      {/* 모바일에서만 핸들 영역 표시 */}
-      {isMobile && (
-        <div
-          className="flex items-center justify-center py-2 cursor-pointer"
-          onClick={() => setShowOptions(false)} // 닫기
-          data-mds="BottomSheetHandleArea"
-        >
-          <div
-            className="h-1 w-9 rounded-[10px] bg-gray-300"
-            data-mds="BottomSheetHandle"
-          ></div>
-        </div>
-      )}
-
-      {/* 컬러 선택 */}
-      <div>
-        <label className="block text-sm font-medium mb-1">컬러</label>
-        <select
-          value={orderData.color}
-          onChange={handleColorChange}
-          className="w-full border border-gray-300 px-2 py-1.5 rounded-md text-sm md:px-3 md:py-2"
-        >
-          {[...new Set(data.variant.map((v) => v.color))].map((color) => (
-            <option key={color} value={color}>
-              {color}
-            </option>
-          ))}
-        </select>
-      </div>
-
-      {/* 사이즈 선택 */}
-      <div>
-        <label className="block text-sm font-medium mb-1">사이즈</label>
-        <select
-          value={orderData.size}
-          onChange={handleSizeChange}
-          className="w-full border border-gray-300 px-2 py-1.5 rounded-md text-sm md:px-3 md:py-2"
-        >
-          <option value="" disabled>
-            사이즈를 선택해주세요
-          </option>
-          {data.variant
-            .filter((v) => v.color === orderData.color)
-            .map((variant, index) => (
-              <option key={index} value={variant.size}>
-                {variant.size}{" "}
-                {variant.quantity === 0
-                  ? "(품절)"
-                  : `(재고: ${variant.quantity}개)`}
-              </option>
-            ))}
-        </select>
-      </div>
-
-      {/* 수량 및 총 금액 */}
-      <div className="flex items-end justify-between mt-2">
-        <div>
-          <label className="block text-sm font-medium mb-1">수량</label>
-          <div className="flex items-center gap-1">
-            <button
-              onClick={decreaseQuantity}
-              className="w-7 h-7 border border-stone-300 bg-gray-100 rounded md:w-8 md:h-8"
-            >
-              -
-            </button>
-            <input
-              type="number"
-              min={1}
-              value={orderData.quantity}
-              onChange={handleQuantityChange}
-              className="w-10 h-7 border border-stone-300 text-center text-sm rounded md:w-12 md:h-8"
-            />
-            <button
-              onClick={increaseQuantity}
-              className="w-7 h-7 border border-stone-300 bg-gray-100 rounded md:w-8 md:h-8"
-            >
-              +
-            </button>
-          </div>
-        </div>
-        <div className="text-right text-lg font-semibold">
-          {calculateTotal().toLocaleString()}원
-        </div>
-      </div>
-    </>
-  );
-
   return (
     <>
       {/* 데스크톱 및 모바일 상단에 표시될 정보 */}
@@ -308,7 +217,19 @@ const ProductDetailInfo = ({ data }: ProductDetailInfoProps) => {
           </div>
         )}
         {!isMobile && (
-          <div className="space-y-3 mb-4">{renderOptionsAndQuantity()}</div>
+          <div className="space-y-3 mb-4">
+            <OrderOptions
+              isMobile={false}
+              orderData={orderData}
+              variantList={data.variant}
+              calculateTotal={calculateTotal}
+              handleColorChange={handleColorChange}
+              handleSizeChange={handleSizeChange}
+              handleQuantityChange={handleQuantityChange}
+              increaseQuantity={increaseQuantity}
+              decreaseQuantity={decreaseQuantity}
+            />
+          </div>
         )}
 
         {/* 연관 태그 */}
@@ -339,86 +260,43 @@ const ProductDetailInfo = ({ data }: ProductDetailInfoProps) => {
         {isMobile ? (
           <div className="fixed bottom-0 left-0 right-0 bg-white p-4 border-t border-gray-200 z-40">
             {showOptions && (
-              <div className="space-y-3 mb-4">{renderOptionsAndQuantity()}</div>
-            )}
-            <div className="flex gap-4">
-              <div className="flex flex-col items-center gap-1">
-                {isWished ? (
-                  <Image
-                    src={"/images/common/red_heart.svg"}
-                    width={24}
-                    height={24}
-                    alt="heart"
-                    onClick={toggleWishlist}
-                  />
-                ) : (
-                  <Image
-                    src={"/images/common/heart.svg"}
-                    width={24}
-                    height={24}
-                    alt="heart"
-                    onClick={toggleWishlist}
-                  />
-                )}
-                <p className="text-xs">{data.wishlistCount.toLocaleString()}</p>
+              <div className="space-y-3 mb-4">
+                <OrderOptions
+                  isMobile={true}
+                  orderData={orderData}
+                  variantList={data.variant}
+                  calculateTotal={calculateTotal}
+                  handleColorChange={handleColorChange}
+                  handleSizeChange={handleSizeChange}
+                  handleQuantityChange={handleQuantityChange}
+                  increaseQuantity={increaseQuantity}
+                  decreaseQuantity={decreaseQuantity}
+                  setShowOptions={setShowOptions}
+                />
               </div>
-              <WhiteButton
-                text={
-                  isCurrentVariantOutOfStock()
-                    ? "품절"
-                    : isLoading
-                    ? "추가 중..."
-                    : "장바구니"
-                }
-                handleClick={handleAddCart}
-                disabled={isLoading || isCurrentVariantOutOfStock()}
-              />
-              <BlackButton
-                text={isCurrentVariantOutOfStock() ? "품절" : "구매하기"}
-                handleClick={handleOrder}
-                disabled={isCurrentVariantOutOfStock()}
-              />
-            </div>
+            )}
+            <BottomActionButtons
+              isWished={isWished}
+              toggleWishlist={toggleWishlist}
+              wishlistCount={data.wishlistCount}
+              isOutOfStock={isCurrentVariantOutOfStock()}
+              isLoading={isLoading}
+              onAddCart={handleAddCart}
+              onOrder={handleOrder}
+              isMobile={true}
+            />
           </div>
         ) : (
-          <div className="flex gap-6">
-            <div className="flex flex-col items-center gap-1">
-              {isWished ? (
-                <Image
-                  src={"/images/common/red_heart.svg"}
-                  width={24}
-                  height={24}
-                  alt="heart"
-                  onClick={toggleWishlist}
-                />
-              ) : (
-                <Image
-                  src={"/images/common/heart.svg"}
-                  width={24}
-                  height={24}
-                  alt="heart"
-                  onClick={toggleWishlist}
-                />
-              )}
-              <p className="text-xs">{data.wishlistCount.toLocaleString()}</p>
-            </div>
-            <WhiteButton
-              text={
-                isCurrentVariantOutOfStock()
-                  ? "품절"
-                  : isLoading
-                  ? "추가 중..."
-                  : "장바구니"
-              }
-              handleClick={handleAddCart}
-              disabled={isLoading || isCurrentVariantOutOfStock()}
-            />
-            <BlackButton
-              text={isCurrentVariantOutOfStock() ? "품절" : "구매하기"}
-              handleClick={handleOrder}
-              disabled={isCurrentVariantOutOfStock()}
-            />
-          </div>
+          <BottomActionButtons
+            isWished={isWished}
+            toggleWishlist={toggleWishlist}
+            wishlistCount={data.wishlistCount}
+            isOutOfStock={isCurrentVariantOutOfStock()}
+            isLoading={isLoading}
+            onAddCart={handleAddCart}
+            onOrder={handleOrder}
+            isMobile={false}
+          />
         )}
       </div>
     </>

--- a/src/app/detail/[id]/_components/DetailUserForm.tsx
+++ b/src/app/detail/[id]/_components/DetailUserForm.tsx
@@ -173,33 +173,35 @@ const ProductDetailInfo = ({ data }: ProductDetailInfoProps) => {
   };
 
   return (
-    <div className="text-black p-6 pb-[8rem] space-y-4">
+    <div className="text-black p-4 space-y-3 md:p-6 md:pb-[8rem] md:space-y-4">
       {/* 브랜드 및 제품명 */}
       <div className="flex justify-between items-center">
         <div className="space-y-1">
-          <div className="text-sm text-gray-500">{data.brand}</div>
-          <div className="text-xl font-semibold">{data.productName}</div>
+          <div className="text-xs text-gray-500 md:text-sm">{data.brand}</div>
+          <div className="text-lg font-semibold md:text-xl">
+            {data.productName}
+          </div>
         </div>
       </div>
 
       {/* 가격 정보 */}
       {data.sale && data.sale > 0 ? (
-        <div className="space-y-1 mb-6">
-          <div className="flex items-center gap-2 mb-2">
+        <div className="space-y-1 mb-4 md:mb-6">
+          <div className="flex items-center gap-2 mb-1 md:mb-2">
             <span className="bg-red-500 text-white px-2 py-1 text-xs font-bold rounded">
               {data.sale}% OFF
             </span>
           </div>
-          <div className="text-2xl font-bold text-red-600">
+          <div className="text-xl font-bold text-red-600 md:text-2xl">
             {(data.salePrice || data.price).toLocaleString()}원
           </div>
-          <div className="text-sm text-gray-400 line-through">
+          <div className="text-xs text-gray-400 line-through md:text-sm">
             {data.price.toLocaleString()}원
           </div>
         </div>
       ) : (
         <div className="space-y-1">
-          <div className="text-2xl font-bold text-black">
+          <div className="text-xl font-bold text-black md:text-2xl">
             {data.price.toLocaleString()}원
           </div>
         </div>
@@ -211,7 +213,7 @@ const ProductDetailInfo = ({ data }: ProductDetailInfoProps) => {
         <select
           value={orderData.color}
           onChange={handleColorChange}
-          className="w-full border border-gray-300 px-3 py-2 rounded-md text-sm"
+          className="w-full border border-gray-300 px-2 py-1.5 rounded-md text-sm md:px-3 md:py-2"
         >
           {[...new Set(data.variant.map((v) => v.color))].map((color) => (
             <option key={color} value={color}>
@@ -227,7 +229,7 @@ const ProductDetailInfo = ({ data }: ProductDetailInfoProps) => {
         <select
           value={orderData.size}
           onChange={handleSizeChange}
-          className="w-full border border-gray-300 px-3 py-2 rounded-md text-sm"
+          className="w-full border border-gray-300 px-2 py-1.5 rounded-md text-sm md:px-3 md:py-2"
         >
           <option value="" disabled>
             사이즈를 선택해주세요
@@ -252,7 +254,7 @@ const ProductDetailInfo = ({ data }: ProductDetailInfoProps) => {
           <div className="flex items-center gap-1">
             <button
               onClick={decreaseQuantity}
-              className="w-8 h-8 border border-stone-300 bg-gray-100 rounded"
+              className="w-7 h-7 border border-stone-300 bg-gray-100 rounded md:w-8 md:h-8"
             >
               -
             </button>
@@ -261,11 +263,11 @@ const ProductDetailInfo = ({ data }: ProductDetailInfoProps) => {
               min={1}
               value={orderData.quantity}
               onChange={handleQuantityChange}
-              className="w-12 h-8 border border-stone-300 text-center text-sm rounded"
+              className="w-10 h-7 border border-stone-300 text-center text-sm rounded md:w-12 md:h-8"
             />
             <button
               onClick={increaseQuantity}
-              className="w-8 h-8 border border-stone-300 bg-gray-100 rounded"
+              className="w-7 h-7 border border-stone-300 bg-gray-100 rounded md:w-8 md:h-8"
             >
               +
             </button>
@@ -278,7 +280,7 @@ const ProductDetailInfo = ({ data }: ProductDetailInfoProps) => {
       </div>
 
       {/* 연관 태그 */}
-      <div className="mt-10">
+      <div className="mt-6 md:mt-10">
         <label className="block text-sm font-medium mb-1">연관 태그</label>
         <div className="flex flex-wrap gap-2">
           <Tag text="기본슬랙스" />
@@ -295,50 +297,52 @@ const ProductDetailInfo = ({ data }: ProductDetailInfoProps) => {
       </div>
 
       {/* 사이즈 추천 등 */}
-      <div className="mt-10">
+      <div className="mt-6 md:mt-10">
         <label className="block text-sm font-medium mb-1 text-neutral-00">
           {data.contents}
         </label>
       </div>
 
       {/* 버튼 영역 */}
-      <div className="flex gap-6 mt-10">
-        <div className="flex flex-col justify-center gap-1">
-          {isWished ? (
-            <Image
-              src={"/images/common/red_heart.svg"}
-              width={30}
-              height={30}
-              alt="heart"
-              onClick={toggleWishlist}
-            />
-          ) : (
-            <Image
-              src={"/images/common/heart.svg"}
-              width={30}
-              height={30}
-              alt="heart"
-              onClick={toggleWishlist}
-            />
-          )}
-          <p className="text-xs">{data.wishlistCount.toLocaleString()}</p>
+      <div className="fixed bottom-0 left-0 right-0 bg-white p-4 border-t border-gray-200 z-40 md:static md:p-0 md:border-none">
+        <div className="flex gap-4 md:gap-6">
+          <div className="flex flex-col items-center gap-1">
+            {isWished ? (
+              <Image
+                src={"/images/common/red_heart.svg"}
+                width={24}
+                height={24}
+                alt="heart"
+                onClick={toggleWishlist}
+              />
+            ) : (
+              <Image
+                src={"/images/common/heart.svg"}
+                width={24}
+                height={24}
+                alt="heart"
+                onClick={toggleWishlist}
+              />
+            )}
+            <p className="text-xs">{data.wishlistCount.toLocaleString()}</p>
+          </div>
+          <WhiteButton
+            text={
+              isCurrentVariantOutOfStock()
+                ? "품절"
+                : isLoading
+                ? "추가 중..."
+                : "장바구니"
+            }
+            handleClick={handleAddCart}
+            disabled={isLoading || isCurrentVariantOutOfStock()}
+          />
+          <BlackButton
+            text={isCurrentVariantOutOfStock() ? "품절" : "구매하기"}
+            handleClick={handleOrder}
+            disabled={isCurrentVariantOutOfStock()}
+          />
         </div>
-        <WhiteButton
-          text={
-            isCurrentVariantOutOfStock()
-              ? "품절"
-              : isLoading
-              ? "추가 중..."
-              : "장바구니"
-          }
-          handleClick={handleAddCart}
-          disabled={isLoading || isCurrentVariantOutOfStock()}
-        />
-        <BlackButton
-          text={isCurrentVariantOutOfStock() ? "품절" : "구매하기"}
-          handleClick={handleOrder}
-          disabled={isCurrentVariantOutOfStock()}
-        />
       </div>
     </div>
   );

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -125,14 +125,12 @@ export default function Header() {
                     onClick={handleMypageClick}
                     className="relative"
                   >
-                    <Image
-                      src="/images/common/mypage.svg"
-                      width={24}
-                      height={24}
-                      alt="mypage"
-                    />
+                    <User className="w-4 h-4" />
                     {showDesktopNotification && (
-                      <div className="absolute -top-1 -right-1 w-3 h-3 bg-red-500 rounded-full border-2 border-white" />
+                      <>
+                        <div className="absolute -top-1.5 -right-1.5 w-3 h-3 bg-red-500 rounded-full border-2 border-white animate-pulse" />
+                        <div className="absolute -top-1.5 -right-1.5 w-3 h-3 bg-red-500 rounded-full animate-ping opacity-75" />
+                      </>
                     )}
                   </Link>
                 </div>

--- a/src/components/ui/TryOnResultModal.tsx
+++ b/src/components/ui/TryOnResultModal.tsx
@@ -31,9 +31,7 @@ const TryOnResultModal = ({ onClose }: TryOnResultModalProps) => {
             <p className="mt-4 text-lg font-semibold text-gray-800">
               옷을 입어보는 중입니다...
             </p>
-            <p className="text-sm text-gray-500">
-              잠시만 기다려주세요.
-            </p>
+            <p className="text-sm text-gray-500">잠시만 기다려주세요.</p>
           </div>
         );
       case "success":
@@ -42,7 +40,7 @@ const TryOnResultModal = ({ onClose }: TryOnResultModalProps) => {
             <h3 className="text-xl font-bold text-center mb-4 text-gray-900">
               아바타 착용 완료!
             </h3>
-            <div className="relative w-full aspect-square rounded-lg overflow-hidden bg-gray-100">
+            <div className="relative w-full aspect-[4/5] sm:aspect-square rounded-lg overflow-hidden bg-gray-100">
               {resultImageUrl ? (
                 <Image
                   src={resultImageUrl}
@@ -62,9 +60,7 @@ const TryOnResultModal = ({ onClose }: TryOnResultModalProps) => {
             <p className="text-lg font-semibold text-red-500">
               오류가 발생했습니다.
             </p>
-            <p className="mt-2 text-sm text-gray-600">
-              다시 시도해주세요.
-            </p>
+            <p className="mt-2 text-sm text-gray-600">다시 시도해주세요.</p>
           </div>
         );
       default:
@@ -74,7 +70,7 @@ const TryOnResultModal = ({ onClose }: TryOnResultModalProps) => {
 
   return (
     <Modal onClose={handleClose} title="아바타 착용 결과">
-      <div className="w-[340px]">{getModalContent()}</div>
+      <div className="w-full max-w-[340px] mx-auto">{getModalContent()}</div>
     </Modal>
   );
 };


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #41

---

## 📝 작업 내용  

상세 페이지에 관한 UI 작업을 주로 작업했다.  

- 아바타 버튼이 계속 화면에 띄워지는 문제 : z 값을 낮추어 해결함   
- 반응형 레이아웃 개선 : 차례대로 모바일/Desktop 순서이다.
  - `DetailMainImg` -> `ProductDetailInfo`(구매..) -> `DetailRecommand` (같이 볼만한 상품) -> `DetailInfo` (상세 제품 설명)
  - 왼쪽 : `DetailMainImg`, `DetailRecommand`, `DetailInfo` / 오른쪽 : `ProductDetailInfo`
- 모바일에서는 구매버튼을 누르면 **옵션 선택**, *수량 조절**이 딱 떠서 스크롤을 내리더라도 언제든 할 수 있도록 개선하였다.
  - [리팩토링] 하나의 파일에 많은 코드가 작성되어져서 2개의 파일로 분리  
  - `DetailOrderOptions` : 주문 옵션 UI
  - `BottomActionButtons` : 하단 버튼(하트, 장바구니, 구매하기) 로직  

---

### 📷 스크린샷 

- 모바일 버전

https://github.com/user-attachments/assets/b99992f6-2e38-48da-baa3-1f3904f97e76

- Desktop 버전  

<img width="1463" height="776" alt="image" src="https://github.com/user-attachments/assets/5e8f2341-9829-438e-bd36-f833394aa7fc" />