### PR TITLE
[style/header]: 헤더 UI 스타일 변경

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
-import Image from "next/image";
 import dynamic from "next/dynamic";
 import { usePathname } from "next/navigation";
 import { Bell, User, Menu, X, Sparkles } from "lucide-react";
@@ -80,6 +79,13 @@ export default function Header() {
 
   if (isLoggedIn === null) return null;
 
+  const getLinkClassName = (
+    base: string,
+    active: string,
+    inactive: string,
+    isActive: boolean
+  ) => [base, isActive ? active : inactive].join(" ");
+
   return (
     <>
       <header className="h-16 sticky top-0 z-50 w-full bg-white/95 backdrop-blur-md border-b border-gray-100">
@@ -93,15 +99,26 @@ export default function Header() {
               <nav className="hidden lg:flex items-center gap-5">
                 {Object.values(CATEGORY)
                   .filter((v) => typeof v === "number")
-                  .map((id) => (
-                    <Link
-                      key={id}
-                      href={id === 0 ? "/" : `/category/${id}`}
-                      className="text-sm font-medium text-gray-700 hover:text-gray-900 transition-colors"
-                    >
-                      {CATEGORY_LABELS[id as CATEGORY]}
-                    </Link>
-                  ))}
+                  .map((id) => {
+                    const href = id === 0 ? "/" : `/category/${id}`;
+                    const isActive =
+                      pathname === href ||
+                      (href !== "/" && pathname.startsWith(href));
+                    return (
+                      <Link
+                        key={id}
+                        href={href}
+                        className={getLinkClassName(
+                          "text-sm transition-colors",
+                          "font-bold text-gray-900",
+                          "font-medium text-gray-700 hover:text-gray-900",
+                          isActive
+                        )}
+                      >
+                        {CATEGORY_LABELS[id as CATEGORY]}
+                      </Link>
+                    );
+                  })}
               </nav>
             </div>
             <div className="flex-grow mx-8">
@@ -117,9 +134,29 @@ export default function Header() {
                   로그인
                 </Link>
               ) : (
-                <div className="flex items-center gap-4 text-sm text-gray-700">
-                  <Link href="/closet">옷장</Link>
-                  <Link href="/cart">장바구니</Link>
+                <div className="flex items-center gap-4 text-sm">
+                  <Link
+                    href="/closet"
+                    className={getLinkClassName(
+                      "transition-colors",
+                      "font-bold text-gray-900",
+                      "text-gray-700 hover:text-gray-900",
+                      pathname.startsWith("/closet")
+                    )}
+                  >
+                    옷장
+                  </Link>
+                  <Link
+                    href="/cart"
+                    className={getLinkClassName(
+                      "transition-colors",
+                      "font-bold text-gray-900",
+                      "text-gray-700 hover:text-gray-900",
+                      pathname.startsWith("/cart")
+                    )}
+                  >
+                    장바구니
+                  </Link>
                   <Link
                     href="/mypage"
                     onClick={handleMypageClick}
@@ -138,7 +175,7 @@ export default function Header() {
             </div>
           </div>
 
-          {/* --- 모바일 헤더 --- */}
+          {/* --- Mobile Header --- */}
           <div className="flex md:hidden items-center gap-2 py-3">
             <Link href="/">
               <h1 className="text-xl font-bold text-gray-900">TIO</h1>
@@ -167,7 +204,7 @@ export default function Header() {
               )}
             </button>
 
-            {/* 모바일 메뉴 */}
+            {/* Mobile Menu */}
             {menuOpen && (
               <div className="fixed top-0 left-0 w-full h-screen bg-white z-[9999] overflow-y-auto">
                 <div className="flex items-center gap-2 px-4 py-3 border-b border-gray-200">
@@ -235,34 +272,72 @@ export default function Header() {
                 <nav className="flex flex-wrap gap-3 px-4 py-4">
                   {Object.values(CATEGORY)
                     .filter((v) => typeof v === "number")
-                    .map((id) => (
-                      <Link
-                        key={id}
-                        href={id === 0 ? "/" : `/category/${id}`}
-                        className="text-base text-gray-800 hover:text-blue-600"
-                        onClick={() => setMenuOpen(false)}
-                      >
-                        {CATEGORY_LABELS[id as CATEGORY]}
-                      </Link>
-                    ))}
+                    .map((id) => {
+                      const href = id === 0 ? "/" : `/category/${id}`;
+                      const isActive =
+                        pathname === href ||
+                        (href !== "/" && pathname.startsWith(href));
+                      return (
+                        <Link
+                          key={id}
+                          href={href}
+                          onClick={() => setMenuOpen(false)}
+                          className={getLinkClassName(
+                            "text-base transition-colors",
+                            "font-bold text-gray-900",
+                            "text-gray-800 hover:text-gray-900",
+                            isActive
+                          )}
+                        >
+                          {CATEGORY_LABELS[id as CATEGORY]}
+                        </Link>
+                      );
+                    })}
                 </nav>
                 <div className="flex flex-col px-4 gap-4 mt-2 border-t border-gray-200 pt-4 pb-6">
                   {isLoggedIn ? (
                     <>
-                      <Link href="/closet" onClick={() => setMenuOpen(false)}>
+                      <Link
+                        href="/closet"
+                        onClick={() => setMenuOpen(false)}
+                        className={getLinkClassName(
+                          "transition-colors",
+                          "font-bold text-gray-900",
+                          "text-gray-800 hover:text-gray-900",
+                          pathname.startsWith("/closet")
+                        )}
+                      >
                         옷장
                       </Link>
-                      <Link href="/cart" onClick={() => setMenuOpen(false)}>
+                      <Link
+                        href="/cart"
+                        onClick={() => setMenuOpen(false)}
+                        className={getLinkClassName(
+                          "transition-colors",
+                          "font-bold text-gray-900",
+                          "text-gray-800 hover:text-gray-900",
+                          pathname.startsWith("/cart")
+                        )}
+                      >
                         장바구니
                       </Link>
-                      <Link href="/mypage" onClick={() => setMenuOpen(false)}>
+                      <Link
+                        href="/mypage"
+                        onClick={() => setMenuOpen(false)}
+                        className={getLinkClassName(
+                          "transition-colors",
+                          "font-bold text-gray-900",
+                          "text-gray-800 hover:text-gray-900",
+                          pathname.startsWith("/mypage")
+                        )}
+                      >
                         마이페이지
                       </Link>
                     </>
                   ) : (
                     <Link
                       href="/signin"
-                      className="flex items-center gap-2 text-base text-gray-800 hover:text-blue-600"
+                      className="flex items-center gap-2 text-base text-gray-800 hover:text-gray-900"
                       onClick={() => setMenuOpen(false)}
                     >
                       <User className="w-5 h-5" />


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #41

---

## 📝 작업 내용

> 유저가 헤더에서 카테고리든 옷장, 장바구니를 갈때 가는 느낌이 느껴지지 않았다.  
> 따라서 눌렀을때, 누른 느낌을 주기위해 유저가 누르면 (즉 활성 상태일때)  
> 스타일적으로 bold 처리를 해주었다.  

---

### 📷 스크린샷 (선택)  

데스크탑/모바일에 일관된 헤더 영역에 일관된 스타일을 적용시켰다.  

- Desktop 인 경우 (헤더 부분에 누르면 볼드 처리되게끔 처리)  

<img width="1489" height="695" alt="image" src="https://github.com/user-attachments/assets/5347dcc6-9049-43d3-9b81-f4c466701671" />

- 모바일인 경우 (햄버거 토글 눌러 이동할때 볼드 처리되어지도록 처리)  

<img width="426" height="430" alt="image" src="https://github.com/user-attachments/assets/9dc3ee52-0056-4620-b973-0ebfb416f21e" />
