### PR TITLE
[fix/qa] 메인페이지 스토리 추가 및 헤더 수정

### DIFF
--- a/src/app/(home)/_components/CategoryProductList.tsx
+++ b/src/app/(home)/_components/CategoryProductList.tsx
@@ -3,7 +3,6 @@
 import React, { useEffect, useState } from "react";
 import ProductCard from "@/components/common/ProductCard";
 import StoryCard from "@/app/story/_components/StoryCard";
-import { dummyStoryList } from "@/mock/story";
 import { StoryResponse } from "@/types/story";
 import { getStories } from "@/api/story";
 import { SortType } from "@/constants/SortType";
@@ -22,7 +21,7 @@ const CategoryProductList = ({ categories }: CategoryProductListProps) => {
   console.log("카테고리별 상품 표시:", categories.length, "개 카테고리");
 
   const router = useRouter();
-  const [stories, setStories] = useState<StoryResponse[]>(dummyStoryList);
+  const [stories, setStories] = useState<StoryResponse[]>([]);
   const [isLoading, setIsLoading] = useState<boolean>(true); // TODO: API 테스트 후 true로 변경
   const [error, setError] = useState<string | null>(null);
 

--- a/src/app/(home)/_components/HomeClientWrapper.tsx
+++ b/src/app/(home)/_components/HomeClientWrapper.tsx
@@ -19,7 +19,7 @@ export default function HomeClientWrapper() {
   const [trending, setTrending] = useState<ProductResponse[]>([]);
   const [ageGroup, setAgeGroup] = useState<ProductResponse[]>([]);
 
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {

--- a/src/app/(home)/_components/MainProductList.tsx
+++ b/src/app/(home)/_components/MainProductList.tsx
@@ -1,9 +1,14 @@
 "use client";
 
-import React from "react";
+import React, { useEffect, useState } from "react";
 import ProductCard from "@/components/common/ProductCard";
 import { ProductResponse } from "@/types/product";
 import { useRouter } from "next/navigation";
+import Spinner from "@/components/common/Spinner";
+import { StoryResponse } from "@/types/story";
+import { getStories } from "@/api/story";
+import { SortType } from "@/constants/SortType";
+import StoryCard from "@/app/story/_components/StoryCard";
 
 type MainProductListProps = {
   recommended: ProductResponse[];
@@ -18,17 +23,57 @@ const MainProductList = ({
 }: MainProductListProps) => {
   const router = useRouter();
 
+  const [stories, setStories] = useState<StoryResponse[]>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleStoryClick = (storyId: number) => {
+    router.push(`/story/${storyId}`);
+  };
+
+  useEffect(() => {
+    const fetchStories = async () => {
+      try {
+        setIsLoading(true);
+        const response = await getStories(SortType.POPULAR, 10);
+        setStories(response.stories);
+      } catch (err) {
+        setError("스토리를 불러오는데 실패했습니다.");
+        console.error("스토리 로딩 실패:", err);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchStories();
+  }, []);
+
   return (
-    <div className="flex flex-col gap-12 pt-3">
+    <div className="flex flex-col gap-12 pt-3 px-4">
       {/* 스토리 영역 */}
-      <div className="flex justify-between items-center mb-4">
-        <h3 className="text-xl font-semibold text-black">패션 스토리</h3>
-        <button
-          className="text-sm text-neutral-500 hover:text-black transition-colors"
-          onClick={() => router.push("/story")}
-        >
-          더보기 →
-        </button>
+      <div>
+        <div className="flex justify-between items-center pr-5 mt-4 mb-2">
+          <h3 className="text-xl font-semibold text-black">패션 스토리</h3>
+          <button
+            className="text-sm text-neutral-500 hover:text-black transition-colors"
+            onClick={() => router.push("/story")}
+          >
+            더보기 →
+          </button>
+        </div>
+        {isLoading && <Spinner />}
+        {error && <p className="text-red-600">{error}</p>}
+        {!isLoading && !error && (
+          <div className="overflow-x-auto">
+            <div className="flex gap-6 px-1">
+              {stories.map((story) => (
+                <div key={story.storyId} className="w-[16rem] flex-shrink-0">
+                  <StoryCard story={story} onClick={handleStoryClick} />
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
       </div>
 
       {/* 추천 상품 섹션 */}
@@ -42,7 +87,6 @@ const MainProductList = ({
           ))}
         </div>
       </section>
-
       {/* 연령대 인기 상품 섹션 */}
       <section>
         <h3 className="text-xl font-bold mb-4 text-black">
@@ -54,7 +98,6 @@ const MainProductList = ({
           ))}
         </div>
       </section>
-
       {/* 랭킹 상품 섹션 */}
       <section>
         <h3 className="text-xl font-bold mb-4 text-black">TIO 인기 상품</h3>

--- a/src/app/story/page.tsx
+++ b/src/app/story/page.tsx
@@ -9,13 +9,12 @@ import StoryLoadingState from "./_components/StoryLoadingState";
 import StoryErrorState from "./_components/StoryErrorState";
 import StoryHeader from "./_components/StoryHeader";
 import StoryGrid from "./_components/StoryGrid";
-import { dummyStoryList } from "@/mock/story";
 import Spinner from "@/components/common/Spinner";
 
 const StoryPage = () => {
   const router = useRouter();
-  const [stories, setStories] = useState<StoryResponse[]>(dummyStoryList);
-  const [isLoading, setIsLoading] = useState<boolean>(true); // TODO: API 테스트 후 true로 변경
+  const [stories, setStories] = useState<StoryResponse[]>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
   const [sortType, setSortType] = useState<SortType>(SortType.POPULAR);
 
@@ -50,16 +49,13 @@ const StoryPage = () => {
 
   return (
     <>
-      {isLoading ? (
-        <Spinner />
-      ) : (
-        <div className="flex flex-col items-center w-screen min-h-screen">
-          <div className="max-w-6xl mx-auto px-4 py-8">
-            <StoryHeader sortType={sortType} onSortChange={handleSortChange} />
-            <StoryGrid stories={stories} onStoryClick={handleStoryClick} />
-          </div>
+      {isLoading && <Spinner />}
+      <div className="flex flex-col items-center w-screen min-h-screen">
+        <div className="max-w-6xl mx-auto px-4 py-8">
+          <StoryHeader sortType={sortType} onSortChange={handleSortChange} />
+          <StoryGrid stories={stories} onStoryClick={handleStoryClick} />
         </div>
-      )}
+      </div>
     </>
   );
 };

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -131,7 +131,12 @@ export default function Header() {
                   <Link
                     href="/story"
                     onClick={() => setMenuOpen(false)}
-                    className="text-sm text-gray-700 hover:text-gray-900"
+                    className={getLinkClassName(
+                      "transition-colors",
+                      "font-bold text-gray-900",
+                      "text-gray-700 hover:text-gray-900",
+                      pathname.startsWith("/story")
+                    )}
                   >
                     스토리
                   </Link>
@@ -145,6 +150,18 @@ export default function Header() {
                 </>
               ) : (
                 <div className="flex items-center gap-4 text-sm">
+                  <Link
+                    href="/story"
+                    onClick={() => setMenuOpen(false)}
+                    className={getLinkClassName(
+                      "transition-colors",
+                      "font-bold text-gray-900",
+                      "text-gray-700 hover:text-gray-900",
+                      pathname.startsWith("/story")
+                    )}
+                  >
+                    스토리
+                  </Link>
                   <Link
                     href="/closet"
                     className={getLinkClassName(


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #81

---

## 📝 작업 내용

1. 회원의 메인페이지 상단에 패션 스토리 섹션을 추가하였습니다.
2. 헤더에 누락된 스토리를 추가하였습니다.
<img width="1440" height="900" alt="스크린샷 2025-07-19 오전 7 05 57" src="https://github.com/user-attachments/assets/b2afff78-cb0f-41f4-823b-fdc8b1fa3e97" />
