### PR TITLE
[fix/qa] 모바일 비로그인 유저 tryon 아이콘 삭제

### DIFF
--- a/src/app/success/page.tsx
+++ b/src/app/success/page.tsx
@@ -1,4 +1,4 @@
-'use client';
+"use client";
 import React, { useEffect, useState, Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { confirmPaymentApi } from "@/api/payment";
@@ -17,45 +17,49 @@ function SuccessContent() {
     const paymentKey = searchParams.get("paymentKey");
     const orderId = searchParams.get("orderId");
     const amount = searchParams.get("amount");
-    
+
     console.log("Success page params:", { paymentKey, orderId, amount });
-    
+
     // 토큰 상태 확인
-    const token = localStorage.getItem('accessToken');
+    const token = localStorage.getItem("accessToken");
     console.log("Success page - 토큰 상태:", {
       hasToken: !!token,
       tokenLength: token?.length,
-      tokenPreview: token?.substring(0, 20) + '...'
+      tokenPreview: token?.substring(0, 20) + "...",
     });
-    
+
     if (paymentKey && orderId && amount) {
       console.log("결제 승인 API 호출 시작...");
-      
-      confirmPaymentApi({ 
-        paymentKey, 
+
+      confirmPaymentApi({
+        paymentKey,
         orderId: orderId,
-        amount: Number(amount) 
+        amount: Number(amount),
       })
         .then((response) => {
           console.log("결제 승인 성공:", response);
           setResult(response);
           setIsLoading(false);
-          
+
           // 결제 성공 후 주문 관련 localStorage 정리
           localStorage.removeItem("orderItems");
           console.log("주문 완료 - localStorage 정리됨");
         })
-        .catch(err => {
+        .catch((err) => {
           console.error("Payment confirmation error:", err);
           console.error("Error details:", {
             status: err.response?.status,
             statusText: err.response?.statusText,
-            data: err.response?.data
+            data: err.response?.data,
           });
-          
+
           // 401/403 에러가 아닌 경우에만 fail 페이지로 이동
           if (err.response?.status !== 401 && err.response?.status !== 403) {
-            router.push(`/fail?message=${err.response?.data?.message || '알 수 없는 오류'}`);
+            router.push(
+              `/fail?message=${
+                err.response?.data?.message || "알 수 없는 오류"
+              }`
+            );
           }
         });
     } else {
@@ -65,7 +69,7 @@ function SuccessContent() {
 
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+      <div className="w-screen min-h-screen bg-gray-50 flex items-center justify-center">
         <div className="text-center">
           <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-black mx-auto mb-4"></div>
           <p className="text-lg text-gray-600">결제 승인 처리 중...</p>
@@ -75,14 +79,16 @@ function SuccessContent() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 py-8">
+    <div className="w-screen min-h-screen bg-gray-50 py-8">
       <div className="container mx-auto px-4 max-w-2xl">
         {/* 성공 헤더 */}
         <div className="text-center mb-8">
           <div className="flex justify-center mb-4">
             <CheckCircle className="w-16 h-16 text-green-500" />
           </div>
-          <h1 className="text-3xl font-bold text-black mb-2">주문이 완료되었습니다!</h1>
+          <h1 className="text-3xl font-bold text-black mb-2">
+            주문이 완료되었습니다!
+          </h1>
           <p className="text-gray-600">
             주문해 주셔서 감사합니다. 주문 내역을 확인해보세요.
           </p>
@@ -95,23 +101,27 @@ function SuccessContent() {
               <CardContent className="p-6">
                 <div className="flex items-center mb-4">
                   <Package className="w-5 h-5 text-black mr-2" />
-                  <h2 className="text-lg font-semibold text-black">주문 정보</h2>
+                  <h2 className="text-lg font-semibold text-black">
+                    주문 정보
+                  </h2>
                 </div>
-                
+
                 <div className="space-y-3">
                   <div className="flex justify-between">
                     <span className="text-gray-600">주문번호</span>
-                    <span className="font-medium text-black">{result.orderId}</span>
+                    <span className="font-medium text-black">
+                      {result.orderId}
+                    </span>
                   </div>
                   <div className="flex justify-between">
                     <span className="text-gray-600">주문일시</span>
                     <span className="font-medium text-black">
-                      {new Date().toLocaleDateString('ko-KR', {
-                        year: 'numeric',
-                        month: 'long',
-                        day: 'numeric',
-                        hour: '2-digit',
-                        minute: '2-digit'
+                      {new Date().toLocaleDateString("ko-KR", {
+                        year: "numeric",
+                        month: "long",
+                        day: "numeric",
+                        hour: "2-digit",
+                        minute: "2-digit",
                       })}
                     </span>
                   </div>
@@ -124,14 +134,16 @@ function SuccessContent() {
               <CardContent className="p-6">
                 <div className="flex items-center mb-4">
                   <CreditCard className="w-5 h-5 text-black mr-2" />
-                  <h2 className="text-lg font-semibold text-black">결제 정보</h2>
+                  <h2 className="text-lg font-semibold text-black">
+                    결제 정보
+                  </h2>
                 </div>
-                
+
                 <div className="space-y-3">
                   <div className="flex justify-between">
                     <span className="text-gray-600">결제 방법</span>
                     <span className="font-medium text-black">
-                      {result.method === 'CARD' ? '신용카드' : result.method}
+                      {result.method === "CARD" ? "신용카드" : result.method}
                     </span>
                   </div>
                   <div className="flex justify-between">
@@ -142,7 +154,9 @@ function SuccessContent() {
                   </div>
                   <div className="flex justify-between">
                     <span className="text-gray-600">결제 상태</span>
-                    <span className="font-medium text-green-600">결제 완료</span>
+                    <span className="font-medium text-green-600">
+                      결제 완료
+                    </span>
                   </div>
                 </div>
               </CardContent>
@@ -153,25 +167,33 @@ function SuccessContent() {
               <CardContent className="p-6">
                 <div className="flex items-center mb-4">
                   <Calendar className="w-5 h-5 text-black mr-2" />
-                  <h2 className="text-lg font-semibold text-black">배송 안내</h2>
+                  <h2 className="text-lg font-semibold text-black">
+                    배송 안내
+                  </h2>
                 </div>
-                
+
                 <div className="space-y-3 text-sm">
                   <div className="bg-blue-50 p-4 rounded-lg">
-                    <p className="text-blue-800 font-medium mb-1">배송 예정일</p>
+                    <p className="text-blue-800 font-medium mb-1">
+                      배송 예정일
+                    </p>
                     <p className="text-blue-700">
-                      {new Date(Date.now() + 2 * 24 * 60 * 60 * 1000).toLocaleDateString('ko-KR', {
-                        year: 'numeric',
-                        month: 'long',
-                        day: 'numeric'
-                      })} 도착 예정
+                      {new Date(
+                        Date.now() + 2 * 24 * 60 * 60 * 1000
+                      ).toLocaleDateString("ko-KR", {
+                        year: "numeric",
+                        month: "long",
+                        day: "numeric",
+                      })}{" "}
+                      도착 예정
                     </p>
                   </div>
                   <p className="text-gray-600">
                     • 주문 확인 후 1-2일 내에 출고됩니다.
                   </p>
                   <p className="text-gray-600">
-                    • 배송 상황은 마이페이지 &gt; 주문내역에서 확인하실 수 있습니다.
+                    • 배송 상황은 마이페이지 &gt; 주문내역에서 확인하실 수
+                    있습니다.
                   </p>
                 </div>
               </CardContent>
@@ -180,13 +202,13 @@ function SuccessContent() {
             {/* 액션 버튼들 */}
             <div className="flex flex-col sm:flex-row gap-3">
               <Button
-                onClick={() => router.push('/mypage/orders')}
+                onClick={() => router.push("/mypage/orders")}
                 className="flex-1 bg-black text-white hover:bg-gray-800"
               >
                 주문내역 확인
               </Button>
               <Button
-                onClick={() => router.push('/')}
+                onClick={() => router.push("/")}
                 variant="outline"
                 className="flex-1 border-black text-black hover:bg-black hover:text-white"
               >
@@ -199,9 +221,11 @@ function SuccessContent() {
         {!result && (
           <Card>
             <CardContent className="p-6 text-center">
-              <p className="text-red-600 mb-4">주문 정보를 불러올 수 없습니다.</p>
+              <p className="text-red-600 mb-4">
+                주문 정보를 불러올 수 없습니다.
+              </p>
               <Button
-                onClick={() => router.push('/')}
+                onClick={() => router.push("/")}
                 className="bg-black text-white hover:bg-gray-800"
               >
                 홈으로 이동
@@ -216,11 +240,13 @@ function SuccessContent() {
 
 export default function SuccessPage() {
   return (
-    <Suspense fallback={
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
-        <div className="text-lg text-gray-600">페이지를 불러오는 중...</div>
-      </div>
-    }>
+    <Suspense
+      fallback={
+        <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+          <div className="text-lg text-gray-600">페이지를 불러오는 중...</div>
+        </div>
+      }
+    >
       <SuccessContent />
     </Suspense>
   );

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -134,7 +134,7 @@ export default function Header() {
                     className={getLinkClassName(
                       "transition-colors",
                       "font-bold text-gray-900",
-                      "text-gray-700 hover:text-gray-900",
+                      "text-sm text-gray-700 hover:text-gray-900",
                       pathname.startsWith("/story")
                     )}
                   >

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -210,24 +210,28 @@ export default function Header() {
             <div className="flex-grow min-w-0">
               <SearchInput />
             </div>
-            <button
-              onClick={openResultModal}
-              className="relative flex-shrink-0"
-              aria-label="알림"
-            >
-              <Image
-                src="/images/common/alarm_filled.svg"
-                width={23}
-                height={23}
-                alt="가상피팅"
-              />
-              {showMobileNotification && (
-                <>
-                  <div className="absolute -top-1 -right-1 w-3 h-3 bg-red-500 rounded-full border-2 border-white animate-pulse" />
-                  <div className="absolute -top-1 -right-1 w-3 h-3 bg-red-500 rounded-full animate-ping opacity-75" />
-                </>
-              )}
-            </button>
+
+            {/* Try On 버튼 */}
+            {isLoggedIn && (
+              <button
+                onClick={openResultModal}
+                className="relative flex-shrink-0"
+                aria-label="알림"
+              >
+                <Image
+                  src="/images/common/alarm_filled.svg"
+                  width={23}
+                  height={23}
+                  alt="가상피팅"
+                />
+                {showMobileNotification && (
+                  <>
+                    <div className="absolute -top-1 -right-1 w-3 h-3 bg-red-500 rounded-full border-2 border-white animate-pulse" />
+                    <div className="absolute -top-1 -right-1 w-3 h-3 bg-red-500 rounded-full animate-ping opacity-75" />
+                  </>
+                )}
+              </button>
+            )}
             <button onClick={toggleMenu} className="relative">
               {menuOpen ? (
                 <X className="w-5 h-5" />
@@ -239,6 +243,7 @@ export default function Header() {
             {/* Mobile Menu */}
             {menuOpen && (
               <div className="fixed top-0 left-0 w-full h-screen bg-white z-[9999] overflow-y-auto">
+                {/* 상단 헤더 */}
                 <div className="flex items-center gap-2 px-4 py-3 border-b border-gray-200">
                   <Link href="/">
                     <h1 className="text-xl font-bold text-gray-900">TIO</h1>
@@ -246,28 +251,35 @@ export default function Header() {
                   <div className="flex-grow min-w-0">
                     <SearchInput onSearch={() => setMenuOpen(false)} />
                   </div>
-                  <button
-                    onClick={openResultModal}
-                    className="relative flex-shrink-0"
-                    aria-label="알림"
-                  >
-                    <Image
-                      src="/images/common/alarm_filled.svg"
-                      width={23}
-                      height={23}
-                      alt="가상피팅"
-                    />
-                    {showMobileNotification && (
-                      <>
-                        <div className="absolute -top-1 -right-1 w-3 h-3 bg-red-500 rounded-full border-2 border-white animate-pulse" />
-                        <div className="absolute -top-1 -right-1 w-3 h-3 bg-red-500 rounded-full animate-ping opacity-75" />
-                      </>
-                    )}
-                  </button>
+
+                  {/* Try On 버튼 */}
+                  {isLoggedIn && (
+                    <button
+                      onClick={openResultModal}
+                      className="relative flex-shrink-0"
+                      aria-label="알림"
+                    >
+                      <Image
+                        src="/images/common/alarm_filled.svg"
+                        width={23}
+                        height={23}
+                        alt="가상피팅"
+                      />
+                      {showMobileNotification && (
+                        <>
+                          <div className="absolute -top-1 -right-1 w-3 h-3 bg-red-500 rounded-full border-2 border-white animate-pulse" />
+                          <div className="absolute -top-1 -right-1 w-3 h-3 bg-red-500 rounded-full animate-ping opacity-75" />
+                        </>
+                      )}
+                    </button>
+                  )}
+
                   <button onClick={toggleMenu}>
                     <X className="w-5 h-5" />
                   </button>
                 </div>
+
+                {/* 모바일 아바타 섹션 & 카테고리 섹션 */}
                 <div className="px-4 py-4 border-b border-gray-200">
                   <div className="flex items-center gap-2 mb-2">
                     <Sparkles className="w-5 h-5 text-blue-500" />
@@ -331,6 +343,8 @@ export default function Header() {
                       );
                     })}
                 </nav>
+
+                {/* 모바일 로그인 유저 하단 CTA 메뉴 */}
                 {isLoggedIn ? (
                   <div className="flex flex-col px-4 gap-4 mt-2 border-t border-gray-200 pt-4 pb-6">
                     <Link
@@ -379,6 +393,7 @@ export default function Header() {
                   </div>
                 ) : (
                   <>
+                    {/* 모바일 비로그인 유저 하단 CTA 메뉴 */}
                     <div className="flex flex-col px-4 gap-4 my-2 border-t border-gray-200 pt-4">
                       <Link
                         href="/story"


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #81 

---

## 📝 작업 내용

- 비로그인 유저 try on 버튼 제외했습니다.
<img width="334" height="725" alt="스크린샷 2025-07-20 오전 11 59 31" src="https://github.com/user-attachments/assets/75a224e6-a562-4de3-863b-a6b349f57051" />

- 아래 사진과 같이 보여지는 문제를 개선했습니다. (결제완료 페이지 PC뷰 가운데 정렬)
<img width="1440" height="900" alt="스크린샷 2025-07-20 오전 11 39 13" src="https://github.com/user-attachments/assets/06b9b94a-caa2-4a73-8b50-9afccc1ccfcf" />

- 헤더 글자 크기를 통일시켰습니다.
<img width="332" height="71" alt="스크린샷 2025-07-20 오후 12 01 20" src="https://github.com/user-attachments/assets/c06871e5-ffc2-4395-a6e7-fa0da7ef5ca2" />
