### PR TITLE
[Fix/Virtual Fitting Modal] 가상 피팅 모달 기능 개선

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -10,6 +10,7 @@ import { getAccessToken } from "@/utils/auth";
 import { CATEGORY, CATEGORY_LABELS } from "@/constants/category";
 import { useAvatarStore } from "@/stores/avatar-store";
 import { useTryOnStore } from "@/stores/try-on-store";
+import { useIsMobile } from "@/hooks/useMediaQuery";
 
 const SearchInput = dynamic(() => import("@/components/common/SearchInput"), {
   ssr: false,
@@ -30,6 +31,8 @@ export default function Header() {
 
   const avatarInfo = useAvatarStore((state) => state.avatarInfo);
   const { status, notificationViewed, viewNotification } = useTryOnStore();
+
+  const isMobile = useIsMobile(); // 768px 이하일 때 true 반환
 
   // --- 알림 로직 ---
   const hasUnreadNotification =
@@ -92,233 +95,13 @@ export default function Header() {
       <header className="h-16 sticky top-0 z-50 w-full bg-white/95 backdrop-blur-md border-b border-gray-100">
         <div className="h-full max-w-[1440px] mx-auto px-4">
           {/* --- 데스크탑 헤더 --- */}
-          <div className="hidden md:flex items-center justify-between py-4">
-            <div className="flex items-center gap-6">
-              <Link href="/">
-                <h1 className="text-2xl font-bold text-gray-900">TIO</h1>
-              </Link>
-              <nav className="hidden lg:flex items-center gap-5">
-                {Object.values(CATEGORY)
-                  .filter((v) => typeof v === "number")
-                  .map((id) => {
-                    const href = id === 0 ? "/" : `/category/${id}`;
-                    const isActive =
-                      pathname === href ||
-                      (href !== "/" && pathname.startsWith(href));
-                    return (
-                      <Link
-                        key={id}
-                        href={href}
-                        className={getLinkClassName(
-                          "text-sm transition-colors",
-                          "font-bold text-gray-900",
-                          "font-medium text-gray-700 hover:text-gray-900",
-                          isActive
-                        )}
-                      >
-                        {CATEGORY_LABELS[id as CATEGORY]}
-                      </Link>
-                    );
-                  })}
-              </nav>
-            </div>
-            <div className="flex-grow mx-8">
-              <SearchInput />
-            </div>
-            <div className="flex items-center gap-4">
-              {!isLoggedIn ? (
-                <>
-                  <Link
-                    href="/story"
-                    onClick={() => setMenuOpen(false)}
-                    className={getLinkClassName(
-                      "transition-colors",
-                      "font-bold text-gray-900",
-                      "text-sm text-gray-700 hover:text-gray-900",
-                      pathname.startsWith("/story")
-                    )}
-                  >
-                    스토리
-                  </Link>
-                  <Link
-                    href="/signin"
-                    className="flex items-center gap-2 text-sm text-gray-700 hover:text-gray-900"
-                  >
-                    <User className="w-4 h-4" />
-                    로그인
-                  </Link>
-                </>
-              ) : (
-                <div className="flex items-center gap-4 text-sm">
-                  <Link
-                    href="/story"
-                    onClick={() => setMenuOpen(false)}
-                    className={getLinkClassName(
-                      "transition-colors",
-                      "font-bold text-gray-900",
-                      "text-gray-700 hover:text-gray-900",
-                      pathname.startsWith("/story")
-                    )}
-                  >
-                    스토리
-                  </Link>
-                  <Link
-                    href="/closet"
-                    className={getLinkClassName(
-                      "transition-colors",
-                      "font-bold text-gray-900",
-                      "text-gray-700 hover:text-gray-900",
-                      pathname.startsWith("/closet")
-                    )}
-                  >
-                    옷장
-                  </Link>
-                  <Link
-                    href="/cart"
-                    className={getLinkClassName(
-                      "transition-colors",
-                      "font-bold text-gray-900",
-                      "text-gray-700 hover:text-gray-900",
-                      pathname.startsWith("/cart")
-                    )}
-                  >
-                    장바구니
-                  </Link>
-                  <Link
-                    href="/mypage"
-                    onClick={handleMypageClick}
-                    className="relative"
-                  >
-                    <User className="w-4 h-4" />
-                    {showDesktopNotification && (
-                      <>
-                        <div className="absolute -top-1.5 -right-1.5 w-3 h-3 bg-red-500 rounded-full border-2 border-white animate-pulse" />
-                        <div className="absolute -top-1.5 -right-1.5 w-3 h-3 bg-red-500 rounded-full animate-ping opacity-75" />
-                      </>
-                    )}
-                  </Link>
-                </div>
-              )}
-            </div>
-          </div>
-
-          {/* --- Mobile Header --- */}
-          <div className="flex md:hidden items-center gap-2 py-3">
-            <Link href="/">
-              <h1 className="text-xl font-bold text-gray-900">TIO</h1>
-            </Link>
-            <div className="flex-grow min-w-0">
-              <SearchInput />
-            </div>
-
-            {/* Try On 버튼 */}
-            {isLoggedIn && (
-              <button
-                onClick={openResultModal}
-                className="relative flex-shrink-0"
-                aria-label="알림"
-              >
-                <Image
-                  src="/images/common/alarm_filled.svg"
-                  width={23}
-                  height={23}
-                  alt="가상피팅"
-                />
-                {showMobileNotification && (
-                  <>
-                    <div className="absolute -top-1 -right-1 w-3 h-3 bg-red-500 rounded-full border-2 border-white animate-pulse" />
-                    <div className="absolute -top-1 -right-1 w-3 h-3 bg-red-500 rounded-full animate-ping opacity-75" />
-                  </>
-                )}
-              </button>
-            )}
-            <button onClick={toggleMenu} className="relative">
-              {menuOpen ? (
-                <X className="w-5 h-5" />
-              ) : (
-                <Menu className="w-5 h-5" />
-              )}
-            </button>
-
-            {/* Mobile Menu */}
-            {menuOpen && (
-              <div className="fixed top-0 left-0 w-full h-screen bg-white z-[9999] overflow-y-auto">
-                {/* 상단 헤더 */}
-                <div className="flex items-center gap-2 px-4 py-3 border-b border-gray-200">
-                  <Link href="/">
-                    <h1 className="text-xl font-bold text-gray-900">TIO</h1>
-                  </Link>
-                  <div className="flex-grow min-w-0">
-                    <SearchInput onSearch={() => setMenuOpen(false)} />
-                  </div>
-
-                  {/* Try On 버튼 */}
-                  {isLoggedIn && (
-                    <button
-                      onClick={openResultModal}
-                      className="relative flex-shrink-0"
-                      aria-label="알림"
-                    >
-                      <Image
-                        src="/images/common/alarm_filled.svg"
-                        width={23}
-                        height={23}
-                        alt="가상피팅"
-                      />
-                      {showMobileNotification && (
-                        <>
-                          <div className="absolute -top-1 -right-1 w-3 h-3 bg-red-500 rounded-full border-2 border-white animate-pulse" />
-                          <div className="absolute -top-1 -right-1 w-3 h-3 bg-red-500 rounded-full animate-ping opacity-75" />
-                        </>
-                      )}
-                    </button>
-                  )}
-
-                  <button onClick={toggleMenu}>
-                    <X className="w-5 h-5" />
-                  </button>
-                </div>
-
-                {/* 모바일 아바타 섹션 & 카테고리 섹션 */}
-                <div className="px-4 py-4 border-b border-gray-200">
-                  <div className="flex items-center gap-2 mb-2">
-                    <Sparkles className="w-5 h-5 text-blue-500" />
-                    <span className="text-sm font-semibold text-gray-900">
-                      내 아바타
-                    </span>
-                  </div>
-                  <div className="bg-gray-50 rounded-lg p-3">
-                    {!isLoggedIn ? (
-                      <p className="text-sm text-gray-500">
-                        아바타를 만들어보세요
-                      </p>
-                    ) : avatarInfo.products &&
-                      avatarInfo.products.length > 0 ? (
-                      <div className="flex gap-3 items-center">
-                        <div className="w-24 h-24 rounded-xl overflow-hidden">
-                          <img
-                            src={avatarInfo.avatarImgUrl}
-                            alt="아바타"
-                            className="object-contain w-full h-full"
-                          />
-                        </div>
-                        <div className="flex flex-col">
-                          <p className="text-sm text-gray-800 font-medium">
-                            현재 착용 중
-                          </p>
-                          <p className="text-xs text-gray-500">
-                            {avatarInfo.products.length}개 아이템
-                          </p>
-                        </div>
-                      </div>
-                    ) : (
-                      <p className="text-sm text-gray-500">
-                        아바타를 착용해보세요
-                      </p>
-                    )}
-                  </div>
-                </div>
-                <nav className="flex flex-wrap gap-3 px-4 py-4">
+          {!isMobile && (
+            <div className="hidden md:flex items-center justify-between py-4">
+              <div className="flex items-center gap-6">
+                <Link href="/">
+                  <h1 className="text-2xl font-bold text-gray-900">TIO</h1>
+                </Link>
+                <nav className="hidden md:flex items-center gap-5">
                   {Object.values(CATEGORY)
                     .filter((v) => typeof v === "number")
                     .map((id) => {
@@ -330,11 +113,10 @@ export default function Header() {
                         <Link
                           key={id}
                           href={href}
-                          onClick={() => setMenuOpen(false)}
                           className={getLinkClassName(
-                            "text-base transition-colors",
+                            "text-sm transition-colors",
                             "font-bold text-gray-900",
-                            "text-gray-800 hover:text-gray-900",
+                            "font-medium text-gray-700 hover:text-gray-900",
                             isActive
                           )}
                         >
@@ -343,24 +125,53 @@ export default function Header() {
                       );
                     })}
                 </nav>
-
-                {/* 모바일 로그인 유저 하단 CTA 메뉴 */}
-                {isLoggedIn ? (
-                  <div className="flex flex-col px-4 gap-4 mt-2 border-t border-gray-200 pt-4 pb-6">
+              </div>
+              <div className="flex-grow mx-8">
+                <SearchInput />
+              </div>
+              <div className="flex items-center gap-4">
+                {!isLoggedIn ? (
+                  <>
                     <Link
                       href="/story"
                       onClick={() => setMenuOpen(false)}
-                      className="text-base text-gray-800 hover:text-gray-900"
+                      className={getLinkClassName(
+                        "transition-colors",
+                        "font-bold text-gray-900",
+                        "text-sm text-gray-700 hover:text-gray-900",
+                        pathname.startsWith("/story")
+                      )}
+                    >
+                      스토리
+                    </Link>
+                    <Link
+                      href="/signin"
+                      className="flex items-center gap-2 text-sm text-gray-700 hover:text-gray-900"
+                    >
+                      <User className="w-4 h-4" />
+                      로그인
+                    </Link>
+                  </>
+                ) : (
+                  <div className="flex items-center gap-4 text-sm">
+                    <Link
+                      href="/story"
+                      onClick={() => setMenuOpen(false)}
+                      className={getLinkClassName(
+                        "transition-colors",
+                        "font-bold text-gray-900",
+                        "text-gray-700 hover:text-gray-900",
+                        pathname.startsWith("/story")
+                      )}
                     >
                       스토리
                     </Link>
                     <Link
                       href="/closet"
-                      onClick={() => setMenuOpen(false)}
                       className={getLinkClassName(
                         "transition-colors",
                         "font-bold text-gray-900",
-                        "text-gray-800 hover:text-gray-900",
+                        "text-gray-700 hover:text-gray-900",
                         pathname.startsWith("/closet")
                       )}
                     >
@@ -368,11 +179,10 @@ export default function Header() {
                     </Link>
                     <Link
                       href="/cart"
-                      onClick={() => setMenuOpen(false)}
                       className={getLinkClassName(
                         "transition-colors",
                         "font-bold text-gray-900",
-                        "text-gray-800 hover:text-gray-900",
+                        "text-gray-700 hover:text-gray-900",
                         pathname.startsWith("/cart")
                       )}
                     >
@@ -380,21 +190,169 @@ export default function Header() {
                     </Link>
                     <Link
                       href="/mypage"
-                      onClick={() => setMenuOpen(false)}
-                      className={getLinkClassName(
-                        "transition-colors",
-                        "font-bold text-gray-900",
-                        "text-gray-800 hover:text-gray-900",
-                        pathname.startsWith("/mypage")
-                      )}
+                      onClick={handleMypageClick}
+                      className="relative"
                     >
-                      마이페이지
+                      <User className="w-4 h-4" />
+                      {showDesktopNotification && (
+                        <>
+                          <div className="absolute -top-1.5 -right-1.5 w-3 h-3 bg-red-500 rounded-full border-2 border-white animate-pulse" />
+                          <div className="absolute -top-1.5 -right-1.5 w-3 h-3 bg-red-500 rounded-full animate-ping opacity-75" />
+                        </>
+                      )}
                     </Link>
                   </div>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* --- Mobile Header --- */}
+          {isMobile && (
+            <div className="flex md:hidden items-center gap-2 py-3">
+              <Link href="/">
+                <h1 className="text-xl font-bold text-gray-900">TIO</h1>
+              </Link>
+              <div className="flex-grow min-w-0">
+                <SearchInput />
+              </div>
+
+              {/* Try On 버튼 */}
+              {isLoggedIn && (
+                <button
+                  onClick={openResultModal}
+                  className="relative flex-shrink-0"
+                  aria-label="알림"
+                >
+                  <Image
+                    src="/images/common/alarm_filled.svg"
+                    width={23}
+                    height={23}
+                    alt="가상피팅"
+                  />
+                  {showMobileNotification && (
+                    <>
+                      <div className="absolute -top-1 -right-1 w-3 h-3 bg-red-500 rounded-full border-2 border-white animate-pulse" />
+                      <div className="absolute -top-1 -right-1 w-3 h-3 bg-red-500 rounded-full animate-ping opacity-75" />
+                    </>
+                  )}
+                </button>
+              )}
+              <button onClick={toggleMenu} className="relative">
+                {menuOpen ? (
+                  <X className="w-5 h-5" />
                 ) : (
-                  <>
-                    {/* 모바일 비로그인 유저 하단 CTA 메뉴 */}
-                    <div className="flex flex-col px-4 gap-4 my-2 border-t border-gray-200 pt-4">
+                  <Menu className="w-5 h-5" />
+                )}
+              </button>
+
+              {/* Mobile Menu */}
+              {menuOpen && (
+                <div className="fixed top-0 left-0 w-full h-screen bg-white z-[9999] overflow-y-auto">
+                  {/* 상단 헤더 */}
+                  <div className="flex items-center gap-2 px-4 py-3 border-b border-gray-200">
+                    <Link href="/">
+                      <h1 className="text-xl font-bold text-gray-900">TIO</h1>
+                    </Link>
+                    <div className="flex-grow min-w-0">
+                      <SearchInput onSearch={() => setMenuOpen(false)} />
+                    </div>
+
+                    {/* Try On 버튼 */}
+                    {isLoggedIn && (
+                      <button
+                        onClick={openResultModal}
+                        className="relative flex-shrink-0"
+                        aria-label="알림"
+                      >
+                        <Image
+                          src="/images/common/alarm_filled.svg"
+                          width={23}
+                          height={23}
+                          alt="가상피팅"
+                        />
+                        {showMobileNotification && (
+                          <>
+                            <div className="absolute -top-1 -right-1 w-3 h-3 bg-red-500 rounded-full border-2 border-white animate-pulse" />
+                            <div className="absolute -top-1 -right-1 w-3 h-3 bg-red-500 rounded-full animate-ping opacity-75" />
+                          </>
+                        )}
+                      </button>
+                    )}
+
+                    <button onClick={toggleMenu}>
+                      <X className="w-5 h-5" />
+                    </button>
+                  </div>
+
+                  {/* 모바일 아바타 섹션 & 카테고리 섹션 */}
+                  <div className="px-4 py-4 border-b border-gray-200">
+                    <div className="flex items-center gap-2 mb-2">
+                      <Sparkles className="w-5 h-5 text-blue-500" />
+                      <span className="text-sm font-semibold text-gray-900">
+                        내 아바타
+                      </span>
+                    </div>
+                    <div className="bg-gray-50 rounded-lg p-3">
+                      {!isLoggedIn ? (
+                        <p className="text-sm text-gray-500">
+                          아바타를 만들어보세요
+                        </p>
+                      ) : avatarInfo.products &&
+                        avatarInfo.products.length > 0 ? (
+                        <div className="flex gap-3 items-center">
+                          <div className="w-24 h-24 rounded-xl overflow-hidden">
+                            <img
+                              src={avatarInfo.avatarImgUrl}
+                              alt="아바타"
+                              className="object-contain w-full h-full"
+                            />
+                          </div>
+                          <div className="flex flex-col">
+                            <p className="text-sm text-gray-800 font-medium">
+                              현재 착용 중
+                            </p>
+                            <p className="text-xs text-gray-500">
+                              {avatarInfo.products.length}개 아이템
+                            </p>
+                          </div>
+                        </div>
+                      ) : (
+                        <p className="text-sm text-gray-500">
+                          아바타를 착용해보세요
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                  <nav className="flex flex-wrap gap-3 px-4 py-4">
+                    {Object.values(CATEGORY)
+                      .filter((v) => typeof v === "number")
+                      .map((id) => {
+                        const href = id === 0 ? "/" : `/category/${id}`;
+                        const isActive =
+                          pathname === href ||
+                          (href !== "/" && pathname.startsWith(href));
+                        return (
+                          <Link
+                            key={id}
+                            href={href}
+                            onClick={() => setMenuOpen(false)}
+                            className={getLinkClassName(
+                              "text-base transition-colors",
+                              "font-bold text-gray-900",
+                              "text-gray-800 hover:text-gray-900",
+                              isActive
+                            )}
+                          >
+                            {CATEGORY_LABELS[id as CATEGORY]}
+                          </Link>
+                        );
+                      })}
+                  </nav>
+
+                  {/* 모바일 로그인 유저 하단 CTA 메뉴 */}
+                  {isLoggedIn ? (
+                    <div className="flex flex-col px-4 gap-4 mt-2 border-t border-gray-200 pt-4 pb-6">
                       <Link
                         href="/story"
                         onClick={() => setMenuOpen(false)}
@@ -402,22 +360,71 @@ export default function Header() {
                       >
                         스토리
                       </Link>
-                    </div>
-                    <div className="flex flex-col px-4 gap-4 my-2 border-t border-gray-200 pt-4">
                       <Link
-                        href="/signin"
-                        className="flex items-center gap-2 text-base text-gray-800 hover:text-gray-900"
+                        href="/closet"
                         onClick={() => setMenuOpen(false)}
+                        className={getLinkClassName(
+                          "transition-colors",
+                          "font-bold text-gray-900",
+                          "text-gray-800 hover:text-gray-900",
+                          pathname.startsWith("/closet")
+                        )}
                       >
-                        <User className="w-5 h-5" />
-                        로그인
+                        옷장
+                      </Link>
+                      <Link
+                        href="/cart"
+                        onClick={() => setMenuOpen(false)}
+                        className={getLinkClassName(
+                          "transition-colors",
+                          "font-bold text-gray-900",
+                          "text-gray-800 hover:text-gray-900",
+                          pathname.startsWith("/cart")
+                        )}
+                      >
+                        장바구니
+                      </Link>
+                      <Link
+                        href="/mypage"
+                        onClick={() => setMenuOpen(false)}
+                        className={getLinkClassName(
+                          "transition-colors",
+                          "font-bold text-gray-900",
+                          "text-gray-800 hover:text-gray-900",
+                          pathname.startsWith("/mypage")
+                        )}
+                      >
+                        마이페이지
                       </Link>
                     </div>
-                  </>
-                )}
-              </div>
-            )}
-          </div>
+                  ) : (
+                    <>
+                      {/* 모바일 비로그인 유저 하단 CTA 메뉴 */}
+                      <div className="flex flex-col px-4 gap-4 my-2 border-t border-gray-200 pt-4">
+                        <Link
+                          href="/story"
+                          onClick={() => setMenuOpen(false)}
+                          className="text-base text-gray-800 hover:text-gray-900"
+                        >
+                          스토리
+                        </Link>
+                      </div>
+                      <div className="flex flex-col px-4 gap-4 my-2 border-t border-gray-200 pt-4">
+                        <Link
+                          href="/signin"
+                          className="flex items-center gap-2 text-base text-gray-800 hover:text-gray-900"
+                          onClick={() => setMenuOpen(false)}
+                        >
+                          <User className="w-5 h-5" />
+                          로그인
+                        </Link>
+                      </div>
+                    </>
+                  )}
+                </div>
+              )}
+            </div>
+          )}
         </div>
       </header>
 

--- a/src/components/ui/TryOnResultModal.tsx
+++ b/src/components/ui/TryOnResultModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useMemo } from "react";
 import Image from "next/image";
 import { useTryOnStore } from "@/stores/try-on-store";
 import { useAvatarStore } from "@/stores/avatar-store";
@@ -15,39 +15,41 @@ interface TryOnResultModalProps {
 }
 
 const TryOnResultModal = ({ onClose }: TryOnResultModalProps) => {
-  const { status, resultImageUrl, viewNotification } = useTryOnStore();
+  const {
+    status,
+    resultImageUrl,
+    viewNotification,
+    reset: resetTryOn,
+  } = useTryOnStore();
 
-  const avatarInfo = useAvatarStore((state) => state.avatarInfo);
-  const setAvatarInfo = useAvatarStore((state) => state.setAvatarInfo);
-  const selectedProductIds = useAvatarStore(
-    (state) => state.selectedProductIds
-  );
-  const isAvatarLoading = useAvatarStore((state) => state.isLoading);
-  const setAvatarLoading = useAvatarStore((state) => state.setLoading);
-  const clearSelectedProducts = useAvatarStore(
-    (state) => state.clearSelectedProducts
-  );
+  const {
+    avatarInfo,
+    setAvatarInfo,
+    selectedProductIds,
+    isLoading: isAvatarLoading,
+    setLoading: setAvatarLoading,
+    clearSelectedProducts,
+  } = useAvatarStore();
 
   const [isClosetLoading, setIsClosetLoading] = useState(false);
   const [isResetLoading, setIsResetLoading] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
 
   useEffect(() => {
-    if (status === "success") {
-      const loadAvatarInfo = async () => {
-        try {
-          setAvatarLoading(true);
-          const data = await fetchLatestAvatarInfo();
-          setAvatarInfo(data);
-        } catch (error) {
-          console.error("아바타 정보 로드 실패", error);
-        } finally {
-          setAvatarLoading(false);
-        }
-      };
-      loadAvatarInfo();
-    }
-  }, [status, setAvatarInfo, setAvatarLoading]);
+    const loadAvatarInfo = async () => {
+      try {
+        setAvatarLoading(true);
+        const data = await fetchLatestAvatarInfo();
+        setAvatarInfo(data);
+      } catch (error) {
+        console.error("아바타 정보 로드 실패", error);
+      } finally {
+        setAvatarLoading(false);
+      }
+    };
+
+    loadAvatarInfo();
+  }, [setAvatarInfo, setAvatarLoading]);
 
   const handleClose = () => {
     viewNotification();
@@ -91,6 +93,7 @@ const TryOnResultModal = ({ onClose }: TryOnResultModalProps) => {
     }
   };
 
+  // 아바타 리셋 처리
   const handleResetAvatar = async () => {
     try {
       setIsResetLoading(true);
@@ -103,6 +106,7 @@ const TryOnResultModal = ({ onClose }: TryOnResultModalProps) => {
         const updatedAvatarInfo = await fetchLatestAvatarInfo(); // 초기화 후 최신 아바타 정보 다시 불러오기
         setAvatarInfo(updatedAvatarInfo); // AvatarStore의 아바타 정보 업데이트
         clearSelectedProducts(); // 선택된 상품 목록 초기화
+        resetTryOn(); // try-on-store 상태 초기화
         setMessage("아바타가 초기화되었습니다.");
       } else {
         setMessage(response.message || "아바타 초기화에 실패했습니다.");
@@ -120,29 +124,45 @@ const TryOnResultModal = ({ onClose }: TryOnResultModalProps) => {
     }
   };
 
+  const displayImageUrl = useMemo(() => {
+    return resultImageUrl || avatarInfo.avatarImgUrl;
+  }, [resultImageUrl, avatarInfo.avatarImgUrl]);
+
   const getModalContent = () => {
-    const displayImageUrl = avatarInfo.avatarImgUrl || resultImageUrl;
+    const renderAvatar = () => (
+      <div className="relative w-full aspect-[4/5] sm:aspect-square rounded-lg overflow-hidden bg-gray-100 mb-4">
+        {displayImageUrl && (
+          <Image
+            src={displayImageUrl}
+            alt="아바타"
+            fill
+            className="object-contain"
+          />
+        )}
+      </div>
+    );
 
     switch (status) {
       case "loading":
         return (
-          <div className="flex flex-col items-center justify-center p-8">
-            <Image
-              src="/images/common/spinner.gif"
-              width={60}
-              height={60}
-              alt="로딩 중"
-            />
-            <p className="mt-4 text-lg font-semibold text-gray-800">
-              옷을 입어보는 중입니다...
-            </p>
-            <p className="text-sm text-gray-500">잠시만 기다려주세요.</p>
-            {isAvatarLoading && (
-              <div className="mt-4 px-3 py-2 rounded-lg text-sm bg-blue-100 text-blue-800 border border-blue-200 flex items-center gap-2">
-                <div className="w-4 h-4 border-2 border-blue-600 border-t-transparent rounded-full animate-spin"></div>
-                옷을 입고 있어요 👕 (최대 1분 소요됩니다)
+          <div className="p-4">
+            <div className="relative w-full aspect-[4/5] sm:aspect-square rounded-lg overflow-hidden bg-gray-100 mb-4">
+              {avatarInfo.avatarImgUrl && (
+                <Image
+                  src={avatarInfo.avatarImgUrl}
+                  alt="현재 아바타"
+                  fill
+                  className="object-contain opacity-50"
+                />
+              )}
+              <div className="absolute inset-0 flex flex-col items-center justify-center bg-white">
+                <div className="w-8 h-8 border-4 border-blue-500 border-t-transparent rounded-full animate-spin" />
+                <p className="mt-4 text-lg font-semibold text-gray-800">
+                  옷을 입어보는 중입니다...
+                </p>
+                <p className="text-sm text-gray-500">잠시만 기다려주세요.</p>
               </div>
-            )}
+            </div>
           </div>
         );
       case "success":
@@ -220,7 +240,6 @@ const TryOnResultModal = ({ onClose }: TryOnResultModalProps) => {
                 </p>
               )}
             </div>
-
             <div className="flex flex-col gap-3">
               <button
                 onClick={handleAddToCloset}
@@ -250,23 +269,14 @@ const TryOnResultModal = ({ onClose }: TryOnResultModalProps) => {
         );
       case "error":
         return (
-          <div className="flex flex-col items-center justify-center p-8">
-            <p className="text-lg font-semibold text-red-500">
+          <div className="p-4">
+            {renderAvatar()}
+            <p className="text-lg font-semibold text-red-500 text-center">
               오류가 발생했습니다.
             </p>
-            <p className="mt-2 text-sm text-gray-600">다시 시도해주세요.</p>
-            <button
-              onClick={handleResetAvatar}
-              disabled={isAvatarLoading || isResetLoading}
-              className={`mt-4 py-2 px-4 rounded-md transition-colors ${
-                isResetLoading || isAvatarLoading
-                  ? "bg-gray-300 text-gray-500 cursor-not-allowed"
-                  : "bg-gray-200 text-gray-800 hover:bg-gray-300"
-              }`}
-            >
-              <RefreshCw className="w-4 h-4 mr-2" />
-              {isResetLoading ? "초기화 중..." : "다시 시도 / 초기화"}
-            </button>
+            <p className="mt-2 text-sm text-gray-600 text-center">
+              다시 시도해주세요.
+            </p>
             {message && (
               <div className="mt-4 px-3 py-2 rounded-lg text-sm bg-yellow-100 text-yellow-800 border border-yellow-200 text-center">
                 {message}
@@ -275,7 +285,24 @@ const TryOnResultModal = ({ onClose }: TryOnResultModalProps) => {
           </div>
         );
       default:
-        return null;
+        return (
+          <div className="p-4">
+            {renderAvatar()}
+            <div className="mt-3 mb-6">
+              <p className="text-sm text-gray-500 mt-2 text-center">
+                피팅할 옷을 선택해주세요.
+              </p>
+            </div>
+            <div className="flex flex-col gap-3">
+              <button
+                onClick={handleClose}
+                className="w-full py-3 border border-gray-300 text-gray-700 rounded-md hover:bg-gray-50 transition-colors"
+              >
+                닫기
+              </button>
+            </div>
+          </div>
+        );
     }
   };
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #81 

---

## 📝 작업 내용

> 데스크탑과 모바일 버전의 헤더가 다른데, 일정 크기에서 (태블릿 정도) 카테고리 탭이 사라지는 바람에
> 햄버거 토글도 보이지 않아, 카테고리로 이동할 수 있는 방법이 없었습니다.
> hidden lg:flex <- 이 부분때문에 카테고리 탭이 숨겨졌던 것입니다.
> 따라서 md 이상에서는 항상 카테고리 탭을 표시하고, 모바일에서는 여전히 햄버거 메뉴를 통해 접근하도록 하였습니다.  

> 모달이 열릴 때 항상 최신 아바타 정보를 불러와 표시하도록 수정했습니다.
> 피팅 전, 후, 초기화 등 모든 상태에서 아바타 이미지가 일관되게 표시됩니다.
> 아바타 초기화 시, 피팅 결과도 함께 초기화되도록 하였습니다.
> 초기화 후 이전 피팅 이미지가 아닌, 현재 아바타(기본 이미지)가 즉시 보이게 됩니다.

---

### 📷 스크린샷 (선택)

#### Before

- 일정 크기에 도달했을때, 카테고리 탭이 아예 보이질 않는 문제    

<img width="813" height="56" alt="image" src="https://github.com/user-attachments/assets/c7d6c1cb-08ae-4cf5-9a2e-3201eca223d8" />  

- 모달 창에 아바타 이미지가 항상 보여야하는데, 보이지 않는 문제  
<img width="407" height="169" alt="image" src="https://github.com/user-attachments/assets/807eba83-d0e2-4c1c-b89e-6a6bb0c76603" />  

#### After    

- 항상 카테고리 탭은 어떤 크기에서도 보이게끔 하였다.  

<img width="766" height="56" alt="image" src="https://github.com/user-attachments/assets/a4813ac1-7025-4d49-bcfd-5b8b759afcd3" />

- 아바타 모달 창에 이제 항상 아바타 이미지가 초기화된 이미지든, 입혀진 상태든 띄워져있게끔 수정하였다.  

<img width="400" height="580" alt="image" src="https://github.com/user-attachments/assets/180ea466-4f54-47ae-b18f-32b03e595fcd" />
<img width="405" height="499" alt="image" src="https://github.com/user-attachments/assets/7a6f3681-8f98-4c37-86cd-26aed64346a1" />

