### PR TITLE
[style/header] 카테고리 탭이 사라지는 현상 해결

### DIFF
--- a/src/components/layout/DesktopHeader.tsx
+++ b/src/components/layout/DesktopHeader.tsx
@@ -42,7 +42,7 @@ export default function DesktopHeader({
         <Link href="/">
           <h1 className="text-2xl font-bold text-gray-900">TIO</h1>
         </Link>
-        <nav className="hidden lg:flex items-center gap-5">
+        <nav className="flex items-center gap-5">
           {Object.values(CATEGORY)
             .filter((v) => typeof v === "number")
             .map((id) => {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #81

---

## 📝 작업 내용

카테고리 탭이 일정 크기에 다다를땐, 사라져서 햄버거 토글 조차 뜨지않아서
카테고리 탭이 보이질 않기에 이와 같이 고쳐주었다.

---

### 📷 스크린샷 (선택)

<img width="781" height="59" alt="image" src="https://github.com/user-attachments/assets/59ff7529-4c74-4c6e-af79-8485094b4f0c" />
