### PR TITLE
[fix/qa] 포스트잇 디자인 변경 및 일부 에러 수정

### DIFF
--- a/src/app/detail/[id]/_components/DetailMainImg.tsx
+++ b/src/app/detail/[id]/_components/DetailMainImg.tsx
@@ -53,9 +53,7 @@ const DetailMainImg = ({ images, productId }: DetailMainImgProps) => {
 
   if (validImages.length === 0) {
     return (
-      <div className="w-full h-[85vh] bg-gray-200 flex items-center justify-center">
-        <p>이미지를 불러올 수 없습니다.</p>
-      </div>
+      <div className="w-full h-[85vh] bg-gray-200 flex items-center justify-center" />
     );
   }
 

--- a/src/app/detail/[id]/_components/DetailOrderOptions.tsx
+++ b/src/app/detail/[id]/_components/DetailOrderOptions.tsx
@@ -85,9 +85,9 @@ const OrderOptions = ({
           onChange={handleSizeChange}
           className="w-full border border-gray-300 px-2 py-1.5 rounded-md text-sm md:px-3 md:py-2"
         >
-          <option value="" disabled>
+          {/* <option value="" disabled>
             사이즈를 선택해주세요
-          </option>
+          </option> */}
           {sizesForSelectedColor.map((variant, index) => (
             <option key={index} value={variant.size}>
               {variant.size}{" "}

--- a/src/app/signin/_components/SigninForm.tsx
+++ b/src/app/signin/_components/SigninForm.tsx
@@ -29,7 +29,9 @@ const SigninForm = ({
   const [passwordError, setPasswordError] = useState(false);
 
   // submit시, 유효성 검사
-  const handleSubmit = () => {
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
     if (emailError || passwordError) {
       openAlert({
         title: "로그인 안내",
@@ -68,27 +70,32 @@ const SigninForm = ({
         onCancel={options.onCancel}
       />
 
-      <div className="flex flex-col items-center gap-4">
-        <InputText
-          value={email}
-          onChange={onEmailChange}
-          placeholder="이메일"
-          type="text"
-          isInvalid={emailError}
-          errorMessage="이메일 형식에 맞게 입력해 주세요."
-        />
-        <InputText
-          value={password}
-          onChange={onPasswordChange}
-          placeholder="비밀번호"
-          type="password"
-          isInvalid={passwordError}
-          errorMessage="비밀번호는 8자 이상으로 영문, 숫자, 특수문자를 포함해 주세요."
-        />
-        <div className="w-full mt-6">
-          <BlackButton text="로그인" handleClick={handleSubmit} />
+      {/* 로그인 포맷 */}
+      <form onSubmit={handleSubmit}>
+        <div className="flex flex-col items-center gap-4">
+          <InputText
+            value={email}
+            onChange={onEmailChange}
+            placeholder="이메일"
+            type="text"
+            isInvalid={emailError}
+            errorMessage="이메일 형식에 맞게 입력해 주세요."
+          />
+          <InputText
+            value={password}
+            onChange={onPasswordChange}
+            placeholder="비밀번호"
+            type="password"
+            isInvalid={passwordError}
+            errorMessage="비밀번호는 8자 이상으로 영문, 숫자, 특수문자를 포함해 주세요."
+          />
+          <div className="w-full mt-6">
+            <BlackButton text="로그인" />
+          </div>
         </div>
-      </div>
+      </form>
+
+      {/* 이메일로 가입 버튼 */}
       <div className="w-full flex gap-4 justify-end my-3">
         <Link href={"/signup"} className="text-sm text-gray-400 cursor-pointer">
           이메일로 가입하기

--- a/src/app/story/[id]/_components/comment/Comment.tsx
+++ b/src/app/story/[id]/_components/comment/Comment.tsx
@@ -3,31 +3,74 @@ import React from "react";
 
 type CommentProps = {
   data: CommentResponse;
+  // 클릭 이벤트를 위함
+  onClick?: (id: number) => void;
 };
 
-const Comment = ({ data }: CommentProps) => {
+const Comment = ({ data, onClick }: CommentProps) => {
+  const handleClick = () => {
+    onClick?.(data.id);
+  };
+
+  // 랜덤한 포스트잇 색상 배열
+  const commentColors = [
+    "bg-blue-100",
+    "bg-red-100",
+    "bg-purple-100",
+    "bg-yellow-100",
+    "bg-orange-100",
+  ];
+
+  // 랜덤한 테이프 색상 배열
+  const tapeColors = [
+    "bg-blue-500",
+    "bg-green-500",
+    "bg-red-500",
+    "bg-purple-500",
+    "bg-indigo-500",
+    "bg-orange-500",
+  ];
+
+  // 랜덤한 색상 선택
+  const randomCommentColor =
+    commentColors[Math.floor(Math.random() * commentColors.length)];
+
+  // 랜덤한 색상 선택
+  const randomTapeColor =
+    tapeColors[Math.floor(Math.random() * tapeColors.length)];
+
   return (
     <div
       key={data.id}
-      className="absolute bg-gradient-to-br from-yellow-100 to-yellow-200 text-black text-xs px-3 py-2 rounded-lg shadow-lg max-w-[180px] break-words z-50 border border-yellow-300 animate-fadeIn hover:scale-105 transition-transform cursor-pointer"
+      className={`absolute ${randomCommentColor} text-black px-4 py-3 rounded-lg shadow-2xl max-w-[200px] break-words z-50
+                 transform transition-all duration-300 ease-in-out
+                 hover:scale-105 hover:rotate-2 hover:shadow-yellow-500/5
+                 active:scale-95 active:rotate-0 cursor-pointer animate-popIn`}
       style={{
         top: data.position.y,
         left: data.position.x,
+        // 포스트잇마다 미묘한 회전 변화를 주어 자연스럽게 보이도록
+        transform: `translate(-50%, -50%) rotate(${Math.random() * 6 - 3}deg)`,
       }}
+      onClick={handleClick}
     >
-      {/* 포스트잇 상단 테이프 효과 */}
-      <div className="absolute -top-1 left-2 w-6 h-2 bg-yellow-400 opacity-60 rounded-sm"></div>
+      {/* 포스트잇 상단 테이프 효과 (세로 및 랜덤 색상) */}
+      <div
+        className={`absolute -top-3 left-1/2 -translate-x-1/2 w-3 h-7 ${randomTapeColor} opacity-70 rounded-md shadow-inner transform rotate-20 origin-center`}
+      ></div>
 
-      <div className="font-semibold text-gray-800 mb-1">{data.username}</div>
-      <div className="text-sm text-gray-700 leading-relaxed mb-2">
+      <div className="font-bold text-gray-800 mb-1 text-xs tracking-wide">
+        {data.username}
+      </div>
+      <div
+        style={{ wordBreak: "keep-all" }}
+        className="text-base text-gray-700 leading-relaxed mb-2 max-h-[80px] overflow-hidden"
+      >
         {data.contents}
       </div>
-      <div className="text-[10px] text-gray-500 text-right">
+      <div className="text-[10px] text-gray-500 text-right opacity-80">
         {data.createdAt.slice(0, 10)}
       </div>
-
-      {/* 포스트잇 그림자 효과 */}
-      <div className="absolute -bottom-1 -right-1 w-full h-full bg-yellow-300 opacity-20 rounded-lg -z-10"></div>
     </div>
   );
 };

--- a/src/app/story/[id]/_components/controller/MenuBar.tsx
+++ b/src/app/story/[id]/_components/controller/MenuBar.tsx
@@ -1,7 +1,5 @@
 import Image from "next/image";
 import { Dispatch, SetStateAction } from "react";
-import { useCustomAlert } from "@/hooks/useCustomAlert";
-import CustomAlert from "@/components/ui/CustomAlert";
 
 type MenuBarProps = {
   liked: boolean;
@@ -15,6 +13,8 @@ type MenuBarProps = {
 
   postComment: boolean;
   setPostComment: Dispatch<SetStateAction<boolean>>;
+
+  onShare: () => void;
 };
 
 const MenuBar = ({
@@ -26,38 +26,10 @@ const MenuBar = ({
   setClothesOn,
   postComment,
   setPostComment,
+  onShare,
 }: MenuBarProps) => {
-  const { isOpen, options, openAlert, closeAlert } = useCustomAlert();
-
-  const handleLinkShare = async () => {
-    try {
-      await navigator.clipboard.writeText(window.location.href);
-      openAlert({
-        title: "링크 복사 완료",
-        message: "링크가 복사되었습니다!",
-        type: "success",
-      });
-    } catch (err) {
-      console.error("링크 복사 실패", err);
-      openAlert({
-        title: "링크 복사 실패",
-        message: "링크 복사에 실패했습니다",
-        type: "error",
-      });
-    }
-  };
-
   return (
     <>
-      <CustomAlert
-        isOpen={isOpen}
-        title={options.title}
-        message={options.message}
-        type={options.type}
-        onConfirm={options.onConfirm || closeAlert}
-        onCancel={options.onCancel}
-      />
-
       <div className="flex flex-col items-center justify-center gap-4 px-3 py-4">
         <div className="flex flex-col items-center text-xs text-neutral-400 gap-1 hover:text-neutral-700 transition-colors">
           <Image
@@ -98,7 +70,7 @@ const MenuBar = ({
             width={25}
             height={25}
             className="cursor-pointer hover:scale-110 transition-transform"
-            onClick={handleLinkShare}
+            onClick={onShare}
           />
           <p className="font-medium">공유하기</p>
         </div>

--- a/src/app/story/[id]/_components/controller/StoryControlBar.tsx
+++ b/src/app/story/[id]/_components/controller/StoryControlBar.tsx
@@ -1,6 +1,8 @@
 import { Dispatch, SetStateAction } from "react";
 import MenuBar from "./MenuBar";
 import NavigateBtn from "./NavigateBtn";
+import CustomAlert from "@/components/ui/CustomAlert";
+import { useCustomAlert } from "@/hooks/useCustomAlert";
 
 type StoryControlBarProps = {
   liked: boolean;
@@ -27,8 +29,37 @@ const StoryControlBar = ({
   onNext,
   onPrev,
 }: StoryControlBarProps) => {
+  const { isOpen, options, openAlert, closeAlert } = useCustomAlert();
+
+  const handleLinkShare = async () => {
+    try {
+      await navigator.clipboard.writeText(window.location.href);
+      openAlert({
+        title: "링크 복사 완료",
+        message: "링크가 복사되었습니다!",
+        type: "success",
+      });
+    } catch (err) {
+      console.error("링크 복사 실패", err);
+      openAlert({
+        title: "링크 복사 실패",
+        message: "링크 복사에 실패했습니다",
+        type: "error",
+      });
+    }
+  };
+
   return (
     <>
+      <CustomAlert
+        isOpen={isOpen}
+        title={options.title}
+        message={options.message}
+        type={options.type}
+        onConfirm={options.onConfirm || closeAlert}
+        onCancel={options.onCancel}
+      />
+
       {/* 메뉴바 */}
       <div className="absolute left-4 bottom-20 bg-white bg-opacity-95 rounded-2xl shadow-lg backdrop-blur-sm">
         <MenuBar
@@ -40,9 +71,9 @@ const StoryControlBar = ({
           setClothesOn={setClothesOn}
           postComment={postComment}
           setPostComment={setPostComment}
+          onShare={handleLinkShare}
         />
       </div>
-
       {/* 스토리 전환 버튼 */}
       <div className="space-y-10 absolute top-2/5 right-4">
         <NavigateBtn onNextPage={onNext} onPrevPage={onPrev} />

--- a/src/app/story/_components/StoryHeader.tsx
+++ b/src/app/story/_components/StoryHeader.tsx
@@ -9,23 +9,21 @@ type StoryHeaderProps = {
 const StoryHeader = ({ sortType, onSortChange }: StoryHeaderProps) => {
   return (
     <>
-      <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center mb-4">
-        <h1 className="text-2xl font-bold text-gray-900 mb-4 sm:mb-0">
-          스토리
-        </h1>
+      <div className="flex justify-between items-start mb-4">
+        <h1 className="text-2xl font-bold text-gray-900">스토리</h1>
 
-        <div className="flex flex-col sm:flex-row space-y-2 sm:space-y-0 sm:space-x-4">
+        <div className="flex gap-2">
           {/* 스토리 관리 버튼 */}
           <Link
             href="/mypage/story"
-            className="px-6 py-2 bg-gray-200 text-gray-800 rounded-lg hover:bg-gray-300 transition-colors text-center"
+            className="px-4 py-2 bg-gray-200 text-gray-800 rounded-lg hover:bg-gray-300 transition-colors text-center"
           >
             스토리 관리
           </Link>
           {/* 스토리 작성 버튼 */}
           <Link
             href="/story/create"
-            className="px-6 py-2 bg-black text-white rounded-lg hover:bg-gray-700 transition-colors text-center"
+            className="px-4 py-2 bg-black text-white rounded-lg hover:bg-gray-700 transition-colors text-center"
           >
             스토리 작성
           </Link>

--- a/src/components/ui/CustomAlert.tsx
+++ b/src/components/ui/CustomAlert.tsx
@@ -118,7 +118,7 @@ export default function CustomAlert({
 
   return (
     <div
-      className={`fixed inset-0 z-[9999] flex items-center justify-center bg-black/50 transition-opacity duration-300 ${
+      className={`fixed z-50 w-screen h-screen top-0 left-0 right-0 bottom-0 flex items-center justify-center bg-black/50 transition-opacity duration-300 ${
         isVisible ? "opacity-100" : "opacity-0"
       }`}
       aria-modal="true"


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #81

---

## 📝 작업 내용

### 포스트잇 디자인 변경

- 변경 전
<img width="1437" height="802" alt="스크린샷 2025-07-22 오전 3 07 06" src="https://github.com/user-attachments/assets/05f3150e-3c5c-4161-99b0-f2dc4f0a354d" />


- 변경 후
<img width="1437" height="802" alt="스크린샷 2025-07-22 오전 3 06 55" src="https://github.com/user-attachments/assets/7226fb4c-9c8e-4794-b2e5-0b9c6cfc1155" />


### 상세페이지 초기 선택지 설정

- 변경 전
<img width="1437" height="802" alt="스크린샷 2025-07-22 오전 3 09 09" src="https://github.com/user-attachments/assets/e33735a7-6709-4805-97d7-4df5af469c71" />

- 변경 후
<img width="1437" height="802" alt="스크린샷 2025-07-22 오전 3 08 48" src="https://github.com/user-attachments/assets/2afaeb0b-40ea-4467-9327-99842a633786" />


### 로그인 포맷 form 태그 감싸기
이메일, 비밀번호를 입력 후, 엔터로 submit 액션이 수행되도록 변경하였습니다.

